### PR TITLE
Add transaction notification listener to every page showing a balance

### DIFF
--- a/app/src/main/java/com/dcrandroid/HomeActivity.kt
+++ b/app/src/main/java/com/dcrandroid/HomeActivity.kt
@@ -246,9 +246,7 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
                     MultiWalletTransactions()
                 } else {
                     val wallet = multiWallet!!.openedWalletsList()[0]
-                    val fragment = TransactionsFragment().setWalletID(wallet.id)
-                    fragment.removeListenersOnStop = false
-                    fragment
+                    TransactionsFragment().setWalletID(wallet.id)
                 }
             }
             2 -> WalletsFragment()

--- a/app/src/main/java/com/dcrandroid/HomeActivity.kt
+++ b/app/src/main/java/com/dcrandroid/HomeActivity.kt
@@ -30,6 +30,7 @@ import com.dcrandroid.data.Constants
 import com.dcrandroid.data.Transaction
 import com.dcrandroid.dialog.*
 import com.dcrandroid.dialog.send.SendDialog
+import com.dcrandroid.dialog.txdetails.TransactionDetailsDialog
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.openedWalletsList
 import com.dcrandroid.extensions.show
@@ -350,8 +351,19 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
             val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
             Utils.sendTransactionNotification(this, notificationManager, dcrFormat.format(amount),
-                    transaction.amount.toInt() + transaction.inputs!!.size, transaction.walletID)
+                    transaction)
         }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        if (intent == null) {
+            return
+        }
+        val tx = intent.getSerializableExtra(Constants.TRANSACTION) as Transaction
+        TransactionDetailsDialog(
+                Transaction.from(multiWallet!!.walletWithID(tx.walletID).getTransaction(tx.hashBytes))
+        ).show(this)
     }
 
     // -- Sync Progress Listener

--- a/app/src/main/java/com/dcrandroid/HomeActivity.kt
+++ b/app/src/main/java/com/dcrandroid/HomeActivity.kt
@@ -245,7 +245,9 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
                     MultiWalletTransactions()
                 } else {
                     val wallet = multiWallet!!.openedWalletsList()[0]
-                    TransactionsFragment().setWalletID(wallet.id)
+                    val fragment = TransactionsFragment().setWalletID(wallet.id)
+                    fragment.removeListenersOnStop = false
+                    fragment
                 }
             }
             2 -> WalletsFragment()

--- a/app/src/main/java/com/dcrandroid/adapter/WalletsAdapter.kt
+++ b/app/src/main/java/com/dcrandroid/adapter/WalletsAdapter.kt
@@ -275,7 +275,7 @@ class WalletsAdapter(val context: Context, val launchIntent: (intent: Intent, re
 
     }
 
-    fun walletBackupVerified(walletID: Long) {
+    fun updateWalletRow(walletID: Long) {
         items.forEachIndexed { index, wallet ->
             if (wallet is Wallet && wallet.id == walletID) {
                 items[index] = multiWallet.walletWithID(walletID)
@@ -284,6 +284,8 @@ class WalletsAdapter(val context: Context, val launchIntent: (intent: Intent, re
             }
         }
     }
+
+    fun walletBackupVerified(walletID: Long) = updateWalletRow(walletID)
 
     inner class WatchOnlyWalletHeader
 

--- a/app/src/main/java/com/dcrandroid/data/Constants.java
+++ b/app/src/main/java/com/dcrandroid/data/Constants.java
@@ -29,6 +29,7 @@ public class Constants {
             TRANSFORMATION = "AES/GCM/NoPadding",
             ENCRYPTION_DATA = "encryption_data",
             ENCRYPTION_IV = "encryption_iv",
+            TRANSACTION = "tx_hash",
             TRANSACTION_CHANNEL_ID = "new_transaction",
             SELECTED_SOURCE_ACCOUNT = "selected_source_account_id",
             SELECTED_DESTINATION_ACCOUNT = "selected_dest_account_no",

--- a/app/src/main/java/com/dcrandroid/data/Transaction.kt
+++ b/app/src/main/java/com/dcrandroid/data/Transaction.kt
@@ -10,6 +10,7 @@ import com.dcrandroid.BuildConfig
 import com.dcrandroid.R
 import com.dcrandroid.util.Utils
 import com.dcrandroid.util.WalletData
+import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import dcrlibwallet.Dcrlibwallet
 import java.io.Serializable
@@ -140,6 +141,12 @@ class Transaction : Serializable {
 
         @SerializedName("address")
         var address: String? = null
+    }
+
+    companion object {
+        fun from(txJson: String): Transaction {
+            return Gson().fromJson(txJson, Transaction::class.java)
+        }
     }
 }
 

--- a/app/src/main/java/com/dcrandroid/dialog/ReceiveDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/ReceiveDialog.kt
@@ -68,6 +68,13 @@ class ReceiveDialog(dismissListener: DialogInterface.OnDismissListener) : FullSc
         }
     }
 
+    override fun onTxOrBalanceUpdateRequired(walletID: Long?) {
+        super.onTxOrBalanceUpdateRequired(walletID)
+        GlobalScope.launch(Dispatchers.Main) {
+            sourceAccountSpinner.refreshBalance()
+        }
+    }
+
     override fun showInfo() {
         InfoDialog(context!!)
                 .setDialogTitle(getString(R.string.receive_dcr))

--- a/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
@@ -129,6 +129,17 @@ class SendDialog(val fragmentActivity: FragmentActivity, dismissListener: Dialog
         clearEstimates()
     }
 
+    override fun onTxOrBalanceUpdateRequired(walletID: Long?) {
+        super.onTxOrBalanceUpdateRequired(walletID)
+        GlobalScope.launch(Dispatchers.Main) {
+            sourceAccountSpinner.refreshBalance()
+
+            if (destinationAddressCard.isSendToAccount) {
+                destinationAddressCard.destinationAccountSpinner.refreshBalance()
+            }
+        }
+    }
+
     override fun onPause() {
         super.onPause()
         savedInstanceState = Bundle()

--- a/app/src/main/java/com/dcrandroid/fragments/BaseFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/BaseFragment.kt
@@ -15,6 +15,9 @@ import dcrlibwallet.*
 open class BaseFragment : Fragment(), SyncProgressListener, TxAndBlockNotificationListener {
 
     var TAG = this.javaClass.name
+    var isForeground = false
+    var requiresDataUpdate = false
+    open var removeListenersOnStop = true
 
     private val walletData: WalletData = WalletData.instance
     internal val multiWallet: MultiWallet
@@ -29,10 +32,26 @@ open class BaseFragment : Fragment(), SyncProgressListener, TxAndBlockNotificati
         multiWallet.addTxAndBlockNotificationListener(this, TAG)
     }
 
+    override fun onResume() {
+        super.onResume()
+        isForeground = true
+        if (requiresDataUpdate) {
+            requiresDataUpdate = false
+            onUpdateData()
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        isForeground = false
+    }
+
     override fun onStop() {
         super.onStop()
-        multiWallet.removeSyncProgressListener(TAG)
-        multiWallet.removeTxAndBlockNotificationListener(TAG)
+        if (removeListenersOnStop) {
+            multiWallet.removeSyncProgressListener(TAG)
+            multiWallet.removeTxAndBlockNotificationListener(TAG)
+        }
     }
 
     fun setToolbarTitle(title: CharSequence, showShadow: Boolean) {
@@ -68,6 +87,8 @@ open class BaseFragment : Fragment(), SyncProgressListener, TxAndBlockNotificati
             homeActivity.switchFragment(position)
         }
     }
+
+    open fun onUpdateData() {}
 
     // -- Sync Progress Listener
 

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -51,6 +51,8 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
         private val newTxHashes = ArrayList<String>()
     }
 
+    override var removeListenersOnStop = false
+
     private val transactions: ArrayList<Transaction> = ArrayList()
     private var adapter: TransactionListAdapter? = null
     private val gson = GsonBuilder().registerTypeHierarchyAdapter(ArrayList::class.java, Deserializer.TransactionDeserializer())
@@ -182,6 +184,11 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
         }
     }
 
+    override fun onUpdateData() {
+        loadBalance()
+        loadTransactions()
+    }
+
     private fun isOffline(): Boolean {
 
         val isWifiConnected = context?.let { NetworkUtil.isWifiConnected(it) }
@@ -202,6 +209,10 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
     }
 
     override fun onTransaction(transactionJson: String?) {
+        if (!isForeground) {
+            requiresDataUpdate = true
+            return
+        }
         loadBalance()
 
         val transaction = gson.fromJson(transactionJson, Transaction::class.java)
@@ -223,6 +234,10 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
     }
 
     override fun onTransactionConfirmed(walletID: Long, hash: String, blockHeight: Int) {
+        if (!isForeground) {
+            requiresDataUpdate = true
+            return
+        }
         loadBalance()
 
         GlobalScope.launch(Dispatchers.Main) {
@@ -237,6 +252,10 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
     }
 
     override fun onBlockAttached(walletID: Long, blockHeight: Int) {
+        if (!isForeground) {
+            requiresDataUpdate = true
+            return
+        }
         loadBalance()
 
         GlobalScope.launch(Dispatchers.Main) {
@@ -248,6 +267,10 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
     }
 
     override fun onSyncCompleted() {
+        if (!isForeground) {
+            requiresDataUpdate = true
+            return
+        }
         loadBalance()
         loadTransactions()
     }

--- a/app/src/main/java/com/dcrandroid/fragments/TransactionsFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/TransactionsFragment.kt
@@ -151,6 +151,10 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
         }
     }
 
+    override fun onUpdateData() {
+        loadTransactions()
+    }
+
     private fun loadTransactions(loadMore: Boolean = false) = GlobalScope.launch(Dispatchers.Default) {
 
         if (loading.get()) {
@@ -210,6 +214,11 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
     }
 
     override fun onTransaction(transactionJson: String?) {
+        if (!isForeground) {
+            requiresDataUpdate = true
+            return
+        }
+
         val transaction = gson.fromJson(transactionJson, Transaction::class.java)
         if (newTxHashes.indexOf(transaction.hash) == -1) {
             newTxHashes.add(transaction.hash)
@@ -227,6 +236,10 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
 
     override fun onTransactionConfirmed(walletID: Long, hash: String, blockHeight: Int) {
         if (walletID == wallet!!.id) {
+            if (!isForeground) {
+                requiresDataUpdate = true
+                return
+            }
             GlobalScope.launch(Dispatchers.Main) {
                 for (i in 0 until transactions.size) {
                     if (transactions[i].hash == hash) {
@@ -240,6 +253,10 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
 
     override fun onBlockAttached(walletID: Long, blockHeight: Int) {
         if (walletID == wallet!!.id) {
+            if (!isForeground) {
+                requiresDataUpdate = true
+                return
+            }
             GlobalScope.launch(Dispatchers.Main) {
                 val unconfirmedTransactions = transactions.filter { it.confirmations <= 2 }.count()
                 if (unconfirmedTransactions > 0) {
@@ -250,6 +267,10 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
     }
 
     override fun onSyncCompleted() {
+        if (!isForeground) {
+            requiresDataUpdate = true
+            return
+        }
         loadTransactions()
     }
 

--- a/app/src/main/java/com/dcrandroid/fragments/TransactionsFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/TransactionsFragment.kt
@@ -151,7 +151,7 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
         }
     }
 
-    override fun onUpdateData() {
+    override fun onTxOrBalanceUpdateRequired(walletID: Long?) {
         loadTransactions()
     }
 

--- a/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
@@ -204,4 +204,15 @@ class WalletsFragment : BaseFragment() {
         }
     }
 
+    override fun onTxOrBalanceUpdateRequired(walletID: Long?) {
+        super.onTxOrBalanceUpdateRequired(walletID)
+
+        GlobalScope.launch(Dispatchers.Main) {
+            if (walletID == null) {
+                adapter.reloadList()
+            } else {
+                adapter.updateWalletRow(walletID)
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/dcrandroid/util/Utils.kt
+++ b/app/src/main/java/com/dcrandroid/util/Utils.kt
@@ -22,6 +22,7 @@ import androidx.core.app.NotificationCompat
 import com.dcrandroid.HomeActivity
 import com.dcrandroid.R
 import com.dcrandroid.data.Constants
+import com.dcrandroid.data.Transaction
 import com.dcrandroid.dialog.InfoDialog
 import dcrlibwallet.Dcrlibwallet
 import dcrlibwallet.Wallet
@@ -158,10 +159,10 @@ object Utils {
     }
 
     fun sendTransactionNotification(context: Context, manager: NotificationManager, amount: String,
-                                    nonce: Int, walletID: Long) {
+                                    transaction: Transaction) {
 
         val multiWallet = WalletData.multiWallet!!
-        val wallet = multiWallet.walletWithID(walletID)
+        val wallet = multiWallet.walletWithID(transaction.walletID)
 
         val title = if (multiWallet.openedWalletsCount() > 1) {
             context.getString(R.string.wallet_new_transaction, wallet.name)
@@ -169,7 +170,7 @@ object Utils {
             context.getString(R.string.new_transaction)
         }
 
-        val incomingNotificationsKey = walletID.toString() + Dcrlibwallet.IncomingTxNotificationsConfigKey
+        val incomingNotificationsKey = transaction.walletID.toString() + Dcrlibwallet.IncomingTxNotificationsConfigKey
         val incomingNotificationConfig = multiWallet.readInt32ConfigValueForKey(incomingNotificationsKey, Constants.DEF_TX_NOTIFICATION)
 
         val notificationSound = when (incomingNotificationConfig) {
@@ -186,6 +187,8 @@ object Utils {
 
         val launchIntent = Intent(context, HomeActivity::class.java)
         launchIntent.action = Constants.NEW_TRANSACTION_NOTIFICATION
+        launchIntent.putExtra(Constants.TRANSACTION, transaction)
+
         val launchPendingIntent = PendingIntent.getActivity(context, 1, launchIntent, PendingIntent.FLAG_UPDATE_CURRENT)
         val notificationBuilder = NotificationCompat.Builder(context, Constants.TRANSACTION_CHANNEL_ID)
                 .setContentTitle(title)
@@ -210,7 +213,7 @@ object Utils {
                 .build()
 
         val notification = notificationBuilder.build()
-        manager.notify(nonce, notification)
+        manager.notify(transaction.amount.toInt() + transaction.inputs!!.size, notification)
         manager.notify(Constants.TRANSACTION_SUMMARY_ID, groupSummary)
     }
 

--- a/app/src/main/java/com/dcrandroid/view/util/AccountCustomSpinner.kt
+++ b/app/src/main/java/com/dcrandroid/view/util/AccountCustomSpinner.kt
@@ -80,6 +80,11 @@ class AccountCustomSpinner(private val fragmentManager: FragmentManager, private
         return wallet.nextAddress(selectedAccount!!.accountNumber)
     }
 
+    fun refreshBalance() {
+        val account = wallet.getAccount(selectedAccount!!.accountNumber)
+        selectedAccount = Account.from(account)
+    }
+
     fun isVisible(): Boolean {
         return spinnerLayout.visibility == View.VISIBLE
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,7 @@
     <string name="new_transaction">New Transaction</string>
     <string name="wallet_new_transaction">[%1$s] New Transaction</string>
     <string name="tx_details_confirmations"><![CDATA[<font color="#41be53">Confirmed</font> &centerdot; %1$d Confirmations]]></string>
+    <string name="tx_details_pending_confirmation"><![CDATA[<font color="#8997A5">Pending</font> &centerdot; %1$d Confirmation]]></string>
 
     <string-array name="timestamp_sort">
         <item>Newest</item>


### PR DESCRIPTION
This fixes a bug that causes the overview & transactions page to not update if a tx notification is received while the app is in the background. Transaction dialog is also shown when a new transaction notification is tapped.  
<img src="https://user-images.githubusercontent.com/19960200/87039891-c0888500-c1e7-11ea-89da-6ff38e453fdb.gif" height="500">