### PR TITLE
Use badge from GitHub actions and no more Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dcrandroid - Decred Mobile Wallet
 
-[![Build Status](https://travis-ci.org/decred/dcrandroid.svg?branch=master)](https://travis-ci.org/decred/dcrandroid)
+[![Build and Test](https://github.com/planetdecred/dcrandroid/workflows/Build%20and%20Test/badge.svg)](https://github.com/planetdecred/dcrandroid/actions)
 
 A Decred Mobile Wallet for android that runs on top of [dcrwallet](https://github.com/decred/dcrwallet).
 


### PR DESCRIPTION
Change the badge in the README to show the status of the GitHub actions and no more the Travis CI status.