### PR TITLE
Fix Github actions build

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ A Decred Mobile Wallet for android that runs on top of [dcrwallet](https://githu
 Android 6.0 or above.
 
 ## Build Instructions
-[Android Studio](https://developer.android.com/studio/index.html) and [Dcrlibwallet](https://github.com/raedahgroup/dcrlibwallet) are required to build this project. Build Dcrlibwallet and copy the generated library into `app/libs` directory. Import this project into Android Studio and build.
+[Android Studio](https://developer.android.com/studio/index.html) and [Dcrlibwallet](https://github.com/planetdecred/dcrlibwallet) are required to build this project. Build Dcrlibwallet and copy the generated library into `app/libs` directory. Import this project into Android Studio and build.

--- a/dcrlibwallet-ci-build.sh
+++ b/dcrlibwallet-ci-build.sh
@@ -27,9 +27,9 @@ fi
 go version
 echo "Building dcrlibwallet"
 export DcrandroidDir=$(pwd)
-mkdir -p $GOPATH/src/github.com/raedahgroup
-git clone https://github.com/raedahgroup/dcrlibwallet $GOPATH/src/github.com/raedahgroup/dcrlibwallet
-cd $GOPATH/src/github.com/raedahgroup/dcrlibwallet
+mkdir -p $GOPATH/src/github.com/planetdecred
+git clone https://github.com/planetdecred/dcrlibwallet $GOPATH/src/github.com/planetdecred/dcrlibwallet
+cd $GOPATH/src/github.com/planetdecred/dcrlibwallet
 export GO111MODULE=on && go mod vendor && export GO111MODULE=off
 gomobile bind -target=android/386
 cp dcrlibwallet.aar $DcrandroidDir/app/libs/dcrlibwallet.aar && cd $DcrandroidDir


### PR DESCRIPTION
Github action build is currently failing because dcrlibwallet repo url changed and golang is having errors with the import path. I fixed it by renaming every instance of 'raedahgroup' to 'planetdecred' in the build script.