### PR TITLE
fix: force text on one line and ellipsize text on small displays for …

### DIFF
--- a/app/src/main/res/layout/activity_tabs.xml
+++ b/app/src/main/res/layout/activity_tabs.xml
@@ -134,6 +134,8 @@
                     android:gravity="center_vertical"
                     android:textColor="@color/white"
                     android:textSize="18sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
                     app:fontFamily="@font/source_sans_pro"
                     />
 
@@ -166,6 +168,8 @@
                     android:gravity="center_vertical"
                     android:textColor="@color/white"
                     android:textSize="18sp"
+                    android:maxLines="1"
+                    android:ellipsize="end"
                     app:fontFamily="@font/source_sans_pro" />
 
             </LinearLayout>


### PR DESCRIPTION
Fixes #492 

- Force the display of the send & receive buttons on one line
- Ellipsize the text on small displays

Example:
![example_ellpsized_buttons](https://user-images.githubusercontent.com/5672954/88625592-5b6ad580-d0a9-11ea-80b3-5f4c7bcc806b.png)