### PR TITLE
Update account data whenever send page is opened

### DIFF
--- a/app/src/main/java/com/dcrandroid/dialog/send/ConfirmTransaction.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/ConfirmTransaction.kt
@@ -34,12 +34,12 @@ class ConfirmTransaction(private val fragmentActivity: FragmentActivity, val sen
 
     lateinit var wallet: Wallet
 
-
     private val selectedAccount: Account
         get() = transactionData.sourceAccount
 
     lateinit var transactionData: TransactionData
     lateinit var authoredTxData: AuthoredTxData
+    private var publishedTx = false
 
     fun setTxData(transactionData: TransactionData, authoredTxData: AuthoredTxData): ConfirmTransaction {
         this.transactionData = transactionData
@@ -107,6 +107,7 @@ class ConfirmTransaction(private val fragmentActivity: FragmentActivity, val sen
                     val op = this@ConfirmTransaction.javaClass.name + ": " + this.javaClass.name + ": txAuthor.broadcast"
                     try {
                         authoredTxData.txAuthor.broadcast(pass.toByteArray())
+                        publishedTx = true
                         passDialog?.dismiss()
                         showSuccess()
                     } catch (e: Exception) {
@@ -134,6 +135,13 @@ class ConfirmTransaction(private val fragmentActivity: FragmentActivity, val sen
                 return@PassPromptUtil false
             }.show()
         }
+
+        go_back.setOnClickListener {
+            dismiss()
+            if (publishedTx) {
+                sendSuccess(true)
+            }
+        }
     }
 
     private fun showSendButton() = GlobalScope.launch(Dispatchers.Main) {
@@ -148,15 +156,11 @@ class ConfirmTransaction(private val fragmentActivity: FragmentActivity, val sen
         success_layout.show()
         send_btn.hide()
         processing_layout.hide()
-        go_back.isEnabled = false
+        go_back.isEnabled = true
         isCancelable = false
 
         sendSuccess(false) // clear estimates
         delay(5000)
-        withContext(Dispatchers.Main) {
-            dismissAllowingStateLoss()
-            sendSuccess(true)
-        }
     }
 
     private fun showProcessing() = GlobalScope.launch(Dispatchers.Main) {

--- a/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
@@ -167,12 +167,17 @@ class SendDialog(val fragmentActivity: FragmentActivity, dismissListener: Dialog
 
             // Update UI based on previously selected send to account.
             val selectedSourceAccount = savedInstanceState!!.getSerializable(Constants.SELECTED_SOURCE_ACCOUNT) as Account?
-            val selectedDestAccount = savedInstanceState!!.getSerializable(Constants.SELECTED_DESTINATION_ACCOUNT) as Account
-            if (multiWallet.walletWithID(selectedSourceAccount!!.walletID) != null) {
-                sourceAccountSpinner.selectedAccount = selectedSourceAccount
+            val selectedDestAccount = savedInstanceState!!.getSerializable(Constants.SELECTED_DESTINATION_ACCOUNT) as Account?
+
+            // To avoid using an account object with invalid data, the account will be fetched from
+            // the wallet instead of using the serialized object.
+            if (selectedSourceAccount != null) {
+                val wallet = multiWallet.walletWithID(selectedSourceAccount.walletID)
+                sourceAccountSpinner.selectedAccount = Account.from(wallet.getAccount(selectedSourceAccount.accountNumber))
             }
-            if (multiWallet.walletWithID(selectedDestAccount.walletID) != null) {
-                destinationAddressCard.destinationAccountSpinner.selectedAccount = selectedDestAccount
+            if (selectedDestAccount != null) {
+                val wallet = multiWallet.walletWithID(selectedDestAccount.walletID)
+                destinationAddressCard.destinationAccountSpinner.selectedAccount = Account.from(wallet.getAccount(selectedDestAccount.accountNumber))
             }
 
             // Show destination address input / spinner depending on which was previously selected.


### PR DESCRIPTION
This pr fixes a bug where the spendable balance is not updated until the app is restarted.