### PR TITLE
restore wallet: fix a bug where correct seed word 'aardvark' is marked as an invalid word

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/RestoreWalletActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/RestoreWalletActivity.kt
@@ -55,7 +55,7 @@ class RestoreWalletActivity : BaseActivity() {
         }
 
     private val validateSeed: (seed: String) -> Boolean = {
-        allSeedWords.indexOf(it) > 0
+        allSeedWords.indexOf(it) >= 0
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
'aardvark' is being marked as invalid because the seed validator is ignoring the first word which happened to be aardvark.
<img src="https://user-images.githubusercontent.com/19960200/100188580-c8249e00-2eea-11eb-95a9-87639c447c3f.png" height="500">