### PR TITLE
tx details: use account number to retrieve account name from wallet

### DIFF
--- a/app/src/main/java/com/dcrandroid/data/Transaction.kt
+++ b/app/src/main/java/com/dcrandroid/data/Transaction.kt
@@ -123,11 +123,8 @@ class Transaction : Serializable {
         @SerializedName("amount")
         var amount: Long = 0
 
-        @SerializedName("account_name")
-        var accountName: String? = null
-
         @SerializedName("account_number")
-        var accountNumber: Int? = null
+        var accountNumber: Int = -1
 
         @SerializedName("previous_outpoint")
         var previousOutpoint: String? = null
@@ -138,10 +135,7 @@ class Transaction : Serializable {
         var index: Int = 0
 
         @SerializedName("account_number")
-        var account: Int = 0
-
-        @SerializedName("account_name")
-        var accountName: String? = null
+        var account: Int = -1
 
         @SerializedName("amount")
         var amount: Long = 0

--- a/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
@@ -176,7 +176,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
     private fun getSourceAccount(): String? {
         for (input in transaction.inputs!!) {
             if (input.accountNumber != null && input.accountNumber != -1) {
-                return input.accountName
+                return wallet.accountName(input.accountNumber)
             }
         }
 
@@ -187,7 +187,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
     private fun getReceiveAccount(): String? {
         for (output in transaction.outputs!!) {
             if (output.account != -1) {
-                return output.accountName
+                return wallet.accountName(output.account)
             }
         }
         return null
@@ -196,9 +196,12 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
     private fun populateInputOutput() {
         val inputs = ArrayList<DropDownItem>()
         for (input in transaction.inputs!!) {
-            val amount = getString(R.string.tx_details_account, CoinFormat.formatDecred(input.amount), input.accountName)
+            val accountName = if (input.accountNumber >= 0) {
+                wallet.accountName(input.accountNumber)
+            } else getString(R.string.external).toLowerCase()
+            val amount = getString(R.string.tx_details_account, CoinFormat.formatDecred(input.amount), accountName)
             var inputBadge = ""
-            if (input.accountNumber != null && input.accountNumber != -1) {
+            if (input.accountNumber != -1) {
                 inputBadge = wallet.name
             }
             inputs.add(DropDownItem(amount, input.previousOutpoint!!, inputBadge))
@@ -208,7 +211,10 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
 
         val outputs = ArrayList<DropDownItem>()
         for (output in transaction.outputs!!) {
-            val amount = getString(R.string.tx_details_account, CoinFormat.formatDecred(output.amount), output.accountName)
+            val accountName = if (output.account >= 0) {
+                wallet.accountName(output.account)
+            } else getString(R.string.external).toLowerCase()
+            val amount = getString(R.string.tx_details_account, CoinFormat.formatDecred(output.amount), accountName)
             var outputBadge = ""
             if (output.account != -1) {
                 outputBadge = wallet.name


### PR DESCRIPTION
Following https://github.com/planetdecred/dcrlibwallet/pull/168, this change is done to avoid displaying 'null' as the account name since the account name property is no longer in the transaction JSON data. The account number is now used to retrieve the account name from the wallet to avoid having an invalid account name saved for a transaction in case an account is renamed.
<img src="https://user-images.githubusercontent.com/19960200/103298635-0dad1d00-49fb-11eb-911e-67b814877b25.png" width="300">
