### PR TITLE
users can now create watch-only wallet from the splash screen

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/SplashScreenActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/SplashScreenActivity.kt
@@ -25,6 +25,7 @@ import com.dcrandroid.BuildConfig
 import com.dcrandroid.HomeActivity
 import com.dcrandroid.R
 import com.dcrandroid.data.Constants
+import com.dcrandroid.dialog.CreateWatchOnlyWallet
 import com.dcrandroid.dialog.FullScreenBottomSheetDialog
 import com.dcrandroid.dialog.InfoDialog
 import com.dcrandroid.extensions.hide
@@ -66,6 +67,13 @@ class SplashScreenActivity : BaseActivity() {
         ll_restore_wallet.setOnClickListener {
             val restoreIntent = Intent(this, RestoreWalletActivity::class.java)
             startActivityForResult(restoreIntent, RESTORE_WALLET_REQUEST_CODE)
+        }
+
+        ll_create_watch_only.setOnClickListener {
+            CreateWatchOnlyWallet {
+                SnackBar.showText(this, R.string.watch_only_wallet_created)
+                proceedToHomeActivity()
+            }.show(this)
         }
 
         if (BuildConfig.IS_TESTNET) {

--- a/app/src/main/res/layout/activity_splash_screen.xml
+++ b/app/src/main/res/layout/activity_splash_screen.xml
@@ -143,7 +143,44 @@
 
             </LinearLayout>
 
+            <LinearLayout
+                android:id="@+id/ll_create_watch_only"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/transparent_ripple_corner_8dp"
+                android:padding="@dimen/margin_padding_size_16"
+                android:layout_marginTop="@dimen/margin_padding_size_16"
+                android:layout_marginBottom="@dimen/margin_padding_size_8"
+                android:layout_marginLeft="@dimen/margin_padding_size_8"
+                android:layout_marginRight="@dimen/margin_padding_size_8"
+                android:gravity="center_vertical"
+                android:elevation="@dimen/shadow_spread"
+                android:clickable="true"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    app:srcCompat="@drawable/ic_watch_only_wallet" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/import_watching_only_wallet"
+                    android:layout_marginStart="@dimen/margin_padding_size_16"
+                    android:textColor="@color/darkBlueTextColor"
+                    android:textSize="@dimen/edit_text_size_18"
+                    android:includeFontPadding="false"
+                    app:fontFamily="@font/source_sans_pro" />
+
+            </LinearLayout>
+
         </LinearLayout>
+
+
+
     </LinearLayout>
 
     <TextView


### PR DESCRIPTION
Requires https://github.com/planetdecred/dcrlibwallet/pull/150

Resolves https://github.com/planetdecred/dcrandroid/issues/524

This PR allows users to create a watch only wallet from the splash screen

**Screenshots**
| <img src="https://user-images.githubusercontent.com/25265396/104746578-bffd1800-574f-11eb-9c28-643e6469d273.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/104746591-c4293580-574f-11eb-871c-61a413f09318.png" height="500"> |
|-|-|
