### PR TITLE
add different notification messages for vote transactions

### DIFF
--- a/app/src/main/java/com/dcrandroid/util/Utils.kt
+++ b/app/src/main/java/com/dcrandroid/util/Utils.kt
@@ -166,8 +166,18 @@ object Utils {
         val wallet = multiWallet.walletWithID(transaction.walletID)
 
         val title = when (transaction.type) {
-            Dcrlibwallet.TxTypeVote -> context.getString(R.string.ticket_voted)
-            Dcrlibwallet.TxTypeRevocation -> context.getString(R.string.ticket_revoked)
+            Dcrlibwallet.TxTypeVote ->
+                if (multiWallet.openedWalletsCount() > 1) {
+                    context.getString(R.string.wallet_ticket_voted, wallet.name)
+                } else {
+                    context.getString(R.string.ticket_voted)
+                }
+            Dcrlibwallet.TxTypeRevocation ->
+                if (multiWallet.openedWalletsCount() > 1) {
+                    context.getString(R.string.wallet_ticket_revoked, wallet.name)
+                } else {
+                    context.getString(R.string.ticket_revoked)
+                }
             else ->
                 if (multiWallet.openedWalletsCount() > 1) {
                     context.getString(R.string.wallet_new_transaction, wallet.name)
@@ -177,7 +187,7 @@ object Utils {
         }
 
         val amount = when (transaction.type) {
-            Dcrlibwallet.TxTypeVote -> context.getString(R.string.vote_reward, transaction.voteReward)
+            Dcrlibwallet.TxTypeVote -> context.getString(R.string.vote_reward, CoinFormat.formatDecred(transaction.voteReward))
             Dcrlibwallet.TxTypeRevocation -> ""
             else ->
                 amount

--- a/app/src/main/java/com/dcrandroid/util/Utils.kt
+++ b/app/src/main/java/com/dcrandroid/util/Utils.kt
@@ -165,10 +165,22 @@ object Utils {
         val multiWallet = WalletData.multiWallet!!
         val wallet = multiWallet.walletWithID(transaction.walletID)
 
-        val title = if (multiWallet.openedWalletsCount() > 1) {
-            context.getString(R.string.wallet_new_transaction, wallet.name)
-        } else {
-            context.getString(R.string.new_transaction)
+        val title = when (transaction.type) {
+            Dcrlibwallet.TxTypeVote -> context.getString(R.string.ticket_voted)
+            Dcrlibwallet.TxTypeRevocation -> context.getString(R.string.ticket_revoked)
+            else ->
+                if (multiWallet.openedWalletsCount() > 1) {
+                    context.getString(R.string.wallet_new_transaction, wallet.name)
+                } else {
+                    context.getString(R.string.new_transaction)
+                }
+        }
+
+        val amount = when (transaction.type) {
+            Dcrlibwallet.TxTypeVote -> context.getString(R.string.vote_reward, transaction.voteReward)
+            Dcrlibwallet.TxTypeRevocation -> ""
+            else ->
+                amount
         }
 
         val incomingNotificationsKey = transaction.walletID.toString() + Dcrlibwallet.IncomingTxNotificationsConfigKey

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,9 +156,11 @@
     <string name="wallet_new_transaction">[%1$s] New Transaction</string>
     <string name="tx_details_confirmations"><![CDATA[<font color="#41be53">Confirmed</font> &centerdot; %1$d Confirmations]]></string>
     <string name="tx_details_pending_confirmation"><![CDATA[<font color="#8997A5">Pending</font> &centerdot; %1$d Confirmation]]></string>
+    <string name="wallet_ticket_voted">[%1$s] A ticket just voted</string>
     <string name="ticket_voted">A ticket just voted</string>
+    <string name="wallet_ticket_revoked">[%1$s] A ticket was revoked</string>
     <string name="ticket_revoked">A ticket was revoked</string>
-    <string name="vote_reward">Vote Reward: %1$d DCR</string>
+    <string name="vote_reward">Vote Reward: %1$s DCR</string>
 
     <string-array name="timestamp_sort">
         <item>Newest</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,6 +156,9 @@
     <string name="wallet_new_transaction">[%1$s] New Transaction</string>
     <string name="tx_details_confirmations"><![CDATA[<font color="#41be53">Confirmed</font> &centerdot; %1$d Confirmations]]></string>
     <string name="tx_details_pending_confirmation"><![CDATA[<font color="#8997A5">Pending</font> &centerdot; %1$d Confirmation]]></string>
+    <string name="ticket_voted">A ticket just voted</string>
+    <string name="ticket_revoked">A ticket was revoked</string>
+    <string name="vote_reward">Vote Reward: %1$d DCR</string>
 
     <string-array name="timestamp_sort">
         <item>Newest</item>
@@ -681,4 +684,5 @@
     <string name="yes_no_votes_percent">Yes: %1$d (%2$.2f%%)  No: %3$d (%4$.2f%%)</string>
     <string name="proposal_name_author">%1$s by %2$s</string>
     <!--/Politeia-->
+
 </resources>


### PR DESCRIPTION
Requires https://github.com/planetdecred/dcrlibwallet/pull/150

resolves https://github.com/planetdecred/dcrandroid/issues/521

This PR adds notification messages for the various Vote Transactions

**Screenshots**
| <img src="https://user-images.githubusercontent.com/25265396/106285803-310af800-6245-11eb-9caa-842ab3a627fd.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/106285821-39633300-6245-11eb-9186-6c3e799d80b6.png" height="500"> |
|-|-|
