### PR TITLE
remove condition requiring user's to cancel sync

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
+++ b/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
@@ -93,11 +93,6 @@ class WalletSettings : BaseActivity() {
 
         remove_wallet.setOnClickListener {
 
-            if (multiWallet!!.isConnectedToDecredNetwork) {
-                SnackBar.showError(this, R.string.disconnect_delete_wallet)
-                return@setOnClickListener
-            }
-
             val dialog = InfoDialog(this)
 
             if (wallet.isWatchingOnlyWallet) {

--- a/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
@@ -122,9 +122,6 @@ class WalletsFragment : BaseFragment() {
                             .setPositiveButton(getString(R.string.ok))
                             .show()
                     return false
-                } else if (multiWallet!!.isConnectedToDecredNetwork) {
-                    SnackBar.showError(context!!, R.string.disconnect_add_wallet)
-                    return false
                 }
 
                 if (activity is HomeActivity) {


### PR DESCRIPTION
This pr removes the conditions that require users to cancel sync before creating/deleting a wallet. The cancellation is now handled in dcrlibwallet