### PR TITLE
add usd equivalent balance to overview page

### DIFF
--- a/app/src/main/java/com/dcrandroid/HomeActivity.kt
+++ b/app/src/main/java/com/dcrandroid/HomeActivity.kt
@@ -294,6 +294,20 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
         }
     }
 
+    fun setToolbarSubTitle(title: CharSequence, showShadow: Boolean) {
+        if (title == "") {
+            toolbar_subtitle.visibility = View.GONE
+        } else {
+            toolbar_subtitle.visibility = View.VISIBLE
+            toolbar_subtitle.text = title
+            app_bar.elevation = if (showShadow) {
+                resources.getDimension(R.dimen.app_bar_elevation)
+            } else {
+                0f
+            }
+        }
+    }
+
     fun checkWifiSync() {
         if (!multiWallet!!.readBoolConfigValueForKey(Dcrlibwallet.SyncOnCellularConfigKey, Constants.DEF_SYNC_ON_CELLULAR)) {
             // Check if wifi is connected

--- a/app/src/main/java/com/dcrandroid/HomeActivity.kt
+++ b/app/src/main/java/com/dcrandroid/HomeActivity.kt
@@ -299,17 +299,12 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
         }
     }
 
-    fun setToolbarSubTitle(title: CharSequence, showShadow: Boolean) {
-        if (title == "") {
+    fun setToolbarSubTitle(subtitle: CharSequence) {
+        if (subtitle == "") {
             toolbar_subtitle.visibility = View.GONE
         } else {
             toolbar_subtitle.visibility = View.VISIBLE
-            toolbar_subtitle.text = title
-            app_bar.elevation = if (showShadow) {
-                resources.getDimension(R.dimen.app_bar_elevation)
-            } else {
-                0f
-            }
+            toolbar_subtitle.text = subtitle
         }
     }
 

--- a/app/src/main/java/com/dcrandroid/HomeActivity.kt
+++ b/app/src/main/java/com/dcrandroid/HomeActivity.kt
@@ -282,6 +282,11 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
 
         showOrHideFab(position)
 
+        // Hide title bar usd balance if not OverviewFragment
+        if (position > 0) {
+            toolbar_subtitle.visibility = View.GONE
+        }
+
         adapter.changeActiveTab(position)
     }
 

--- a/app/src/main/java/com/dcrandroid/dialog/send/AmountInputHelper.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/AmountInputHelper.kt
@@ -20,6 +20,7 @@ import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
 import com.dcrandroid.extensions.toggleVisibility
 import com.dcrandroid.util.CoinFormat
+import com.dcrandroid.util.CurrencyUtil
 import com.dcrandroid.util.GetExchangeRate
 import com.dcrandroid.util.WalletData
 import dcrlibwallet.Dcrlibwallet
@@ -29,12 +30,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
-import java.math.RoundingMode
 import java.text.DecimalFormat
 
 
 const val AmountRelativeSize = 0.625f
-val usdAmountFormat: DecimalFormat = DecimalFormat("0.0000")
 val usdAmountFormat2: DecimalFormat = DecimalFormat("0.00")
 val dcrFormat = DecimalFormat("#.########")
 
@@ -194,7 +193,7 @@ class AmountInputHelper(private val layout: LinearLayout, private val scrollToBo
             layout.send_amount.removeTextChangedListener(this)
 
             dcrAmount = BigDecimal(coin)
-            usdAmount = dcrToUSD(exchangeDecimal, dcrAmount!!.toDouble())
+            usdAmount = CurrencyUtil.dcrToUSD(exchangeDecimal, dcrAmount!!.toDouble())
 
             if (currencyIsDCR) {
                 val dcr = Dcrlibwallet.amountAtom(coin)
@@ -252,10 +251,10 @@ class AmountInputHelper(private val layout: LinearLayout, private val scrollToBo
         if (enteredAmount != null) {
             if (currencyIsDCR) {
                 dcrAmount = enteredAmount!!
-                usdAmount = dcrToUSD(exchangeDecimal, dcrAmount!!.toDouble())
+                usdAmount = CurrencyUtil.dcrToUSD(exchangeDecimal, dcrAmount!!.toDouble())
             } else {
                 usdAmount = enteredAmount!!
-                dcrAmount = usdToDCR(exchangeDecimal, usdAmount!!.toDouble())
+                dcrAmount = CurrencyUtil.usdToDCR(exchangeDecimal, usdAmount!!.toDouble())
             }
         } else {
             dcrAmount = null
@@ -312,7 +311,7 @@ class AmountInputHelper(private val layout: LinearLayout, private val scrollToBo
         }
 
         if (dcrAmount != null) {
-            usdAmount = dcrToUSD(exchangeDecimal, dcrAmount!!.toDouble())
+            usdAmount = CurrencyUtil.dcrToUSD(exchangeDecimal, dcrAmount!!.toDouble())
         }
 
         displayEquivalentValue()
@@ -331,27 +330,27 @@ class AmountInputHelper(private val layout: LinearLayout, private val scrollToBo
     }
 }
 
-fun dcrToFormattedUSD(exchangeDecimal: BigDecimal?, dcr: Double, scale: Int = 4): String {
-    if (scale == 4) {
-        return usdAmountFormat.format(
-                dcrToUSD(exchangeDecimal, dcr)!!.setScale(scale, BigDecimal.ROUND_HALF_EVEN).toDouble())
-    }
-
-    return usdAmountFormat2.format(
-            dcrToUSD(exchangeDecimal, dcr)!!.setScale(scale, BigDecimal.ROUND_HALF_EVEN).toDouble())
-}
-
-fun dcrToUSD(exchangeDecimal: BigDecimal?, dcr: Double): BigDecimal? {
-    val dcrDecimal = BigDecimal(dcr)
-    return exchangeDecimal?.multiply(dcrDecimal)
-}
-
-fun usdToDCR(exchangeDecimal: BigDecimal?, usd: Double): BigDecimal? {
-    if (exchangeDecimal == null) {
-        return null
-    }
-
-    val usdDecimal = BigDecimal(usd)
-    // using 8 to be safe
-    return usdDecimal.divide(exchangeDecimal, 8, RoundingMode.HALF_EVEN)
-}
+//fun dcrToFormattedUSD(exchangeDecimal: BigDecimal?, dcr: Double, scale: Int = 4): String {
+//    if (scale == 4) {
+//        return usdAmountFormat.format(
+//                dcrToUSD(exchangeDecimal, dcr)!!.setScale(scale, BigDecimal.ROUND_HALF_EVEN).toDouble())
+//    }
+//
+//    return usdAmountFormat2.format(
+//            dcrToUSD(exchangeDecimal, dcr)!!.setScale(scale, BigDecimal.ROUND_HALF_EVEN).toDouble())
+//}
+//
+//fun dcrToUSD(exchangeDecimal: BigDecimal?, dcr: Double): BigDecimal? {
+//    val dcrDecimal = BigDecimal(dcr)
+//    return exchangeDecimal?.multiply(dcrDecimal)
+//}
+//
+//fun usdToDCR(exchangeDecimal: BigDecimal?, usd: Double): BigDecimal? {
+//    if (exchangeDecimal == null) {
+//        return null
+//    }
+//
+//    val usdDecimal = BigDecimal(usd)
+//    // using 8 to be safe
+//    return usdDecimal.divide(exchangeDecimal, 8, RoundingMode.HALF_EVEN)
+//}

--- a/app/src/main/java/com/dcrandroid/dialog/send/AmountInputHelper.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/AmountInputHelper.kt
@@ -329,28 +329,3 @@ class AmountInputHelper(private val layout: LinearLayout, private val scrollToBo
         }
     }
 }
-
-//fun dcrToFormattedUSD(exchangeDecimal: BigDecimal?, dcr: Double, scale: Int = 4): String {
-//    if (scale == 4) {
-//        return usdAmountFormat.format(
-//                dcrToUSD(exchangeDecimal, dcr)!!.setScale(scale, BigDecimal.ROUND_HALF_EVEN).toDouble())
-//    }
-//
-//    return usdAmountFormat2.format(
-//            dcrToUSD(exchangeDecimal, dcr)!!.setScale(scale, BigDecimal.ROUND_HALF_EVEN).toDouble())
-//}
-//
-//fun dcrToUSD(exchangeDecimal: BigDecimal?, dcr: Double): BigDecimal? {
-//    val dcrDecimal = BigDecimal(dcr)
-//    return exchangeDecimal?.multiply(dcrDecimal)
-//}
-//
-//fun usdToDCR(exchangeDecimal: BigDecimal?, usd: Double): BigDecimal? {
-//    if (exchangeDecimal == null) {
-//        return null
-//    }
-//
-//    val usdDecimal = BigDecimal(usd)
-//    // using 8 to be safe
-//    return usdDecimal.divide(exchangeDecimal, 8, RoundingMode.HALF_EVEN)
-//}

--- a/app/src/main/java/com/dcrandroid/dialog/send/ConfirmTransaction.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/ConfirmTransaction.kt
@@ -21,10 +21,7 @@ import com.dcrandroid.dialog.PasswordPromptDialog
 import com.dcrandroid.dialog.PinPromptDialog
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
-import com.dcrandroid.util.CoinFormat
-import com.dcrandroid.util.PassPromptTitle
-import com.dcrandroid.util.PassPromptUtil
-import com.dcrandroid.util.Utils
+import com.dcrandroid.util.*
 import dcrlibwallet.Dcrlibwallet
 import dcrlibwallet.Wallet
 import kotlinx.android.synthetic.main.confirm_send_sheet.*
@@ -61,7 +58,7 @@ class ConfirmTransaction(private val fragmentActivity: FragmentActivity, val sen
 
         val dcrAmount = CoinFormat.formatDecred(Dcrlibwallet.amountAtom(transactionData.dcrAmount.toDouble()))
         val amountStr = if (transactionData.exchangeDecimal != null) {
-            val usdAmount = dcrToFormattedUSD(transactionData.exchangeDecimal, transactionData.dcrAmount.toDouble(), 2)
+            val usdAmount = CurrencyUtil.dcrToFormattedUSD(transactionData.exchangeDecimal, transactionData.dcrAmount.toDouble(), 2)
             HtmlCompat.fromHtml(getString(R.string.x_dcr_usd, dcrAmount, usdAmount), 0)
         } else {
             getString(R.string.x_dcr, dcrAmount)

--- a/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
@@ -30,6 +30,7 @@ import com.dcrandroid.dialog.InfoDialog
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
 import com.dcrandroid.util.CoinFormat
+import com.dcrandroid.util.CurrencyUtil
 import com.dcrandroid.util.SnackBar
 import com.dcrandroid.util.Utils
 import com.dcrandroid.view.util.AccountCustomSpinner
@@ -405,8 +406,8 @@ class SendDialog(val fragmentActivity: FragmentActivity, dismissListener: Dialog
             val feeCoin = Dcrlibwallet.amountCoin(feeAtom)
             val totalCostCoin = Dcrlibwallet.amountCoin(totalCostAtom)
 
-            val feeUSD = dcrToFormattedUSD(amountHelper.exchangeDecimal, feeCoin)
-            val totalCostUSD = dcrToFormattedUSD(amountHelper.exchangeDecimal, totalCostCoin, 2)
+            val feeUSD = CurrencyUtil.dcrToFormattedUSD(amountHelper.exchangeDecimal, feeCoin)
+            val totalCostUSD = CurrencyUtil.dcrToFormattedUSD(amountHelper.exchangeDecimal, totalCostCoin, 2)
 
             feeSpanned = HtmlCompat.fromHtml(getString(R.string.x_dcr_usd, feeString, feeUSD), 0)
             totalCostSpanned = HtmlCompat.fromHtml(getString(R.string.x_dcr_usd, totalCostString, totalCostUSD), 0)

--- a/app/src/main/java/com/dcrandroid/fragments/BaseFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/BaseFragment.kt
@@ -66,10 +66,10 @@ open class BaseFragment : Fragment(), SyncProgressListener, TxAndBlockNotificati
         }
     }
 
-    fun setToolbarSubTitle(title: CharSequence, showShadow: Boolean) {
+    fun setToolbarSubTitle(subtitle: CharSequence) {
         if (activity is HomeActivity) {
             val homeActivity = activity as HomeActivity
-            homeActivity.setToolbarSubTitle(title, showShadow)
+            homeActivity.setToolbarSubTitle(subtitle)
         }
     }
 

--- a/app/src/main/java/com/dcrandroid/fragments/BaseFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/BaseFragment.kt
@@ -66,6 +66,13 @@ open class BaseFragment : Fragment(), SyncProgressListener, TxAndBlockNotificati
         }
     }
 
+    fun setToolbarSubTitle(title: CharSequence, showShadow: Boolean) {
+        if (activity is HomeActivity) {
+            val homeActivity = activity as HomeActivity
+            homeActivity.setToolbarSubTitle(title, showShadow)
+        }
+    }
+
     fun refreshNavigationTabs() {
         if (activity is HomeActivity) {
             val homeActivity = activity as HomeActivity

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -366,9 +366,9 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
         val totalBalanceAtom = multiWallet!!.totalWalletBalance()
         val totalBalanceCoin = Dcrlibwallet.amountCoin(totalBalanceAtom)
         val formattedUSD = HtmlCompat.fromHtml(getString(R.string.usd_symbol_format, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalBalanceCoin, 2)), 0)
-        usdBalanceTextView.text = formattedUSD
 
         GlobalScope.launch(Dispatchers.Main) {
+            usdBalanceTextView.text = formattedUSD
             usdBalanceTextView.show()
         }
     }

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -216,7 +216,7 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
 
         if (mainBalanceIsVisible()) {
             setToolbarTitle(CoinFormat.format(multiWallet!!.totalWalletBalance(), 0.7f), true)
-            if (isExchangeEnabled()) {
+            if (exchangeDecimal != null) {
                 val formattedUSD = HtmlCompat.fromHtml(getString(R.string.usd_symbol_format, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalBalanceCoin, 2)), 0)
                 setToolbarSubTitle(formattedUSD)
             }
@@ -228,13 +228,13 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
 
     private fun loadBalance() = GlobalScope.launch(Dispatchers.Main) {
         balanceTextView.text = CoinFormat.format(multiWallet!!.totalWalletBalance(), 0.5f)
-        val totalCostAtom = multiWallet!!.totalWalletBalance()
-        val totalCostCoin = Dcrlibwallet.amountCoin(totalCostAtom)
+        val totalBalanceAtom = multiWallet!!.totalWalletBalance()
+        val totalBalanceCoin = Dcrlibwallet.amountCoin(totalBalanceAtom)
 
         if (mainBalanceIsVisible()) {
             setToolbarTitle(CoinFormat.format(multiWallet!!.totalWalletBalance(), 0.7f), true)
             if (exchangeDecimal != null) {
-                val formattedUSD = HtmlCompat.fromHtml(getString(R.string.usd_symbol_format, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalCostCoin, 2)), 0)
+                val formattedUSD = HtmlCompat.fromHtml(getString(R.string.usd_symbol_format, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalBalanceCoin, 2)), 0)
                 setToolbarSubTitle(formattedUSD)
             }
         }
@@ -363,9 +363,9 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
     override fun onExchangeRateSuccess(rate: GetExchangeRate.BittrexRateParser) {
         exchangeDecimal = rate.usdRate
 
-        val totalCostAtom = multiWallet!!.totalWalletBalance()
-        val totalCostCoin = Dcrlibwallet.amountCoin(totalCostAtom)
-        val formattedUSD = HtmlCompat.fromHtml(getString(R.string.usd_symbol_format, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalCostCoin, 2)), 0)
+        val totalBalanceAtom = multiWallet!!.totalWalletBalance()
+        val totalBalanceCoin = Dcrlibwallet.amountCoin(totalBalanceAtom)
+        val formattedUSD = HtmlCompat.fromHtml(getString(R.string.usd_symbol_format, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalBalanceCoin, 2)), 0)
         usdBalanceTextView.text = formattedUSD
 
         GlobalScope.launch(Dispatchers.Main) {

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -68,7 +68,6 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
     internal lateinit var noTransactionsTextView: TextView
     internal lateinit var transactionsLayout: LinearLayout
 
-    var exchangeEnabled = true
     var exchangeDecimal: BigDecimal? = null
 
     private lateinit var syncLayout: LinearLayout
@@ -92,8 +91,6 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-
-        fetchExchangeRate()
 
         adapter = TransactionListAdapter(context!!, transactions)
 
@@ -153,6 +150,8 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
         mixer_status_rv.adapter = MixerStatusAdapter()
         setMixerStatus()
         multiWallet?.setAccountMixerNotification(this)
+
+        fetchExchangeRate()
     }
 
     private fun setMixerStatus() = GlobalScope.launch(Dispatchers.Main) {
@@ -212,18 +211,18 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
     }
 
     override fun onScrollChanged() {
-        val totalCostAtom = multiWallet!!.totalWalletBalance()
-        val totalCostCoin = Dcrlibwallet.amountCoin(totalCostAtom)
+        val totalBalanceAtom = multiWallet!!.totalWalletBalance()
+        val totalBalanceCoin = Dcrlibwallet.amountCoin(totalBalanceAtom)
 
         if (mainBalanceIsVisible()) {
             setToolbarTitle(CoinFormat.format(multiWallet!!.totalWalletBalance(), 0.7f), true)
             if (isExchangeEnabled()) {
-                val formattedUSD = HtmlCompat.fromHtml(getString(R.string.dcr_usd, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalCostCoin, 2)), 0)
-                setToolbarSubTitle(formattedUSD, true)
+                val formattedUSD = HtmlCompat.fromHtml(getString(R.string.usd_symbol_format, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalBalanceCoin, 2)), 0)
+                setToolbarSubTitle(formattedUSD)
             }
         } else {
             setToolbarTitle(R.string.overview, false)
-            setToolbarSubTitle("", false)
+            setToolbarSubTitle("")
         }
     }
 
@@ -234,9 +233,9 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
 
         if (mainBalanceIsVisible()) {
             setToolbarTitle(CoinFormat.format(multiWallet!!.totalWalletBalance(), 0.7f), true)
-            if (isExchangeEnabled()) {
-                val formattedUSD = HtmlCompat.fromHtml(getString(R.string.dcr_usd, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalCostCoin, 2)), 0)
-                setToolbarSubTitle(formattedUSD, true)
+            if (exchangeDecimal != null) {
+                val formattedUSD = HtmlCompat.fromHtml(getString(R.string.usd_symbol_format, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalCostCoin, 2)), 0)
+                setToolbarSubTitle(formattedUSD)
             }
         }
     }
@@ -346,12 +345,9 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
     }
 
     private fun isExchangeEnabled(): Boolean {
-        val multiWallet = WalletData.multiWallet!!
-        val currencyConversion = multiWallet.readInt32ConfigValueForKey(Dcrlibwallet.CurrencyConversionConfigKey, Constants.DEF_CURRENCY_CONVERSION)
+        val currencyConversion = multiWallet!!.readInt32ConfigValueForKey(Dcrlibwallet.CurrencyConversionConfigKey, Constants.DEF_CURRENCY_CONVERSION)
 
-        exchangeEnabled = currencyConversion > 0
-
-        return exchangeEnabled
+        return currencyConversion > 0
     }
 
     private fun fetchExchangeRate() {
@@ -369,7 +365,7 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
 
         val totalCostAtom = multiWallet!!.totalWalletBalance()
         val totalCostCoin = Dcrlibwallet.amountCoin(totalCostAtom)
-        val formattedUSD = HtmlCompat.fromHtml(getString(R.string.dcr_usd, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalCostCoin, 2)), 0)
+        val formattedUSD = HtmlCompat.fromHtml(getString(R.string.usd_symbol_format, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalCostCoin, 2)), 0)
         usdBalanceTextView.text = formattedUSD
 
         GlobalScope.launch(Dispatchers.Main) {

--- a/app/src/main/java/com/dcrandroid/util/CurrencyUtil.kt
+++ b/app/src/main/java/com/dcrandroid/util/CurrencyUtil.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018-2019 The Decred developers
+ * Use of this source code is governed by an ISC
+ * license that can be found in the LICENSE file.
+ */
+
+package com.dcrandroid.util
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.text.DecimalFormat
+
+val usdAmountFormat: DecimalFormat = DecimalFormat("###,###,###,###,###.####")
+val usdAmountFormat2: DecimalFormat = DecimalFormat("###,###,###,###,###.##")
+
+object CurrencyUtil {
+    fun dcrToFormattedUSD(exchangeDecimal: BigDecimal?, dcr: Double, scale: Int = 4): String {
+        if (scale == 4) {
+            return usdAmountFormat.format(
+                    dcrToUSD(exchangeDecimal, dcr)!!.setScale(scale, BigDecimal.ROUND_HALF_EVEN).toDouble())
+        }
+        return usdAmountFormat2.format(
+                dcrToUSD(exchangeDecimal, dcr)!!.setScale(scale, BigDecimal.ROUND_HALF_EVEN).toDouble())
+    }
+
+    fun dcrToUSD(exchangeDecimal: BigDecimal?, dcr: Double): BigDecimal? {
+        val dcrDecimal = BigDecimal(dcr)
+        return exchangeDecimal?.multiply(dcrDecimal)
+    }
+
+    fun usdToDCR(exchangeDecimal: BigDecimal?, usd: Double): BigDecimal? {
+        if (exchangeDecimal == null) {
+            return null
+        }
+
+        val usdDecimal = BigDecimal(usd)
+        // using 8 to be safe
+        return usdDecimal.divide(exchangeDecimal, 8, RoundingMode.HALF_EVEN)
+    }
+}

--- a/app/src/main/res/drawable/light_grey_border_8dp.xml
+++ b/app/src/main/res/drawable/light_grey_border_8dp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
+    <corners android:radius="8dp"/>
+<!--    <solid android:color="@android:color/white" />-->
+    <stroke android:width="1dip" android:color="#8997A5"/>
+</shape>

--- a/app/src/main/res/drawable/light_grey_border_8dp.xml
+++ b/app/src/main/res/drawable/light_grey_border_8dp.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
     <corners android:radius="8dp"/>
-<!--    <solid android:color="@android:color/white" />-->
-    <stroke android:width="1dip" android:color="#8997A5"/>
+    <stroke android:width="0.5dp" android:color="#C4CBD2"/>
 </shape>

--- a/app/src/main/res/layout/activity_tabs.xml
+++ b/app/src/main/res/layout/activity_tabs.xml
@@ -63,9 +63,9 @@
                     android:textColor="#3D5873"
                     android:paddingTop="@dimen/margin_padding_size_4"
                     android:paddingBottom="@dimen/margin_padding_size_4"
-                    android:paddingStart="@dimen/margin_padding_size_8"
-                    android:paddingEnd="@dimen/margin_padding_size_8"
-                    android:layout_marginStart="8dp"
+                    android:paddingStart="@dimen/margin_padding_size_6"
+                    android:paddingEnd="@dimen/margin_padding_size_6"
+                    android:layout_marginStart="@dimen/margin_padding_size_8"
                     android:textSize="@dimen/edit_text_size_14"
                     android:visibility="gone"
                     app:fontFamily="@font/source_sans_pro" />

--- a/app/src/main/res/layout/activity_tabs.xml
+++ b/app/src/main/res/layout/activity_tabs.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2018-2019 The Decred developers
   ~ Use of this source code is governed by an ISC
   ~ license that can be found in the LICENSE file.
@@ -54,6 +53,22 @@
                     android:includeFontPadding="false"
                     app:fontFamily="@font/source_sans_pro"
                     android:layout_marginStart="16dp" />
+
+                <TextView
+                    android:id="@+id/toolbar_subtitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:includeFontPadding="false"
+                    android:background="@drawable/light_grey_border_8dp"
+                    android:textColor="#3D5873"
+                    android:paddingTop="@dimen/margin_padding_size_4"
+                    android:paddingBottom="@dimen/margin_padding_size_4"
+                    android:paddingStart="@dimen/margin_padding_size_8"
+                    android:paddingEnd="@dimen/margin_padding_size_8"
+                    android:layout_marginStart="8dp"
+                    android:textSize="@dimen/edit_text_size_14"
+                    android:visibility="gone"
+                    app:fontFamily="@font/source_sans_pro" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_overview.xml
+++ b/app/src/main/res/layout/fragment_overview.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2018-2019 The Decred developers
   ~ Use of this source code is governed by an ISC
   ~ license that can be found in the LICENSE file.
@@ -36,12 +35,18 @@
                 tools:text="315.08193725 DCR" />
 
             <TextView
+                android:id="@+id/tv_visible_usd_wallet_balance"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:includeFontPadding="false"
-                android:text="@string/current_total_balance"
-                android:textColor="#596d81"
-                android:textSize="14sp"
+                android:background="@drawable/light_grey_border_8dp"
+                android:textColor="#3D5873"
+                android:paddingTop="@dimen/margin_padding_size_4"
+                android:paddingBottom="@dimen/margin_padding_size_4"
+                android:paddingStart="@dimen/margin_padding_size_12"
+                android:paddingEnd="@dimen/margin_padding_size_12"
+                android:textSize="@dimen/edit_text_size_16"
+                android:visibility="gone"
                 app:fontFamily="@font/source_sans_pro" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_overview.xml
+++ b/app/src/main/res/layout/fragment_overview.xml
@@ -43,8 +43,8 @@
                 android:textColor="#3D5873"
                 android:paddingTop="@dimen/margin_padding_size_4"
                 android:paddingBottom="@dimen/margin_padding_size_4"
-                android:paddingStart="@dimen/margin_padding_size_12"
-                android:paddingEnd="@dimen/margin_padding_size_12"
+                android:paddingStart="@dimen/margin_padding_size_8"
+                android:paddingEnd="@dimen/margin_padding_size_8"
                 android:textSize="@dimen/edit_text_size_16"
                 android:visibility="gone"
                 app:fontFamily="@font/source_sans_pro" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -428,7 +428,7 @@
 
     <string name="x_dcr">%1$s DCR</string>
     <string name="x_usd">%1$s USD</string>
-    <string name="dcr_usd">$%1$s</string>
+    <string name="usd_symbol_format">$%1$s</string>
     <string name="_dcr"><![CDATA[<font color="#596D81">—</font> DCR]]></string>
     <string name="_dcr_usd"><![CDATA[<font color="#596d81">—</font> DCR <font color="#8997a5">(— USD)</font>]]></string>
     <string name="x_dcr_usd"><![CDATA[%1$s DCR <font color="#8997a5">($%2$s USD)</font>]]></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,8 +211,8 @@
         <item>Error</item>
         <item>Critical</item>
     </string-array>
-    
-    
+
+
     <string-array name="notification_options">
         <item>None</item>
         <item>Silent</item>
@@ -428,6 +428,7 @@
 
     <string name="x_dcr">%1$s DCR</string>
     <string name="x_usd">%1$s USD</string>
+    <string name="dcr_usd">$%1$s</string>
     <string name="_dcr"><![CDATA[<font color="#596D81">—</font> DCR]]></string>
     <string name="_dcr_usd"><![CDATA[<font color="#596d81">—</font> DCR <font color="#8997a5">(— USD)</font>]]></string>
     <string name="x_dcr_usd"><![CDATA[%1$s DCR <font color="#8997a5">($%2$s USD)</font>]]></string>


### PR DESCRIPTION
Reolves #537 

This PR adds the USD equivalent of a user's DCR balance to the overview page.

**NB**: Currency Conversion needs to be enabled in the settings page for this to work.

**Screenshots**
| <img src="https://user-images.githubusercontent.com/25265396/114099281-71789900-98ba-11eb-94ca-fd640cf93a53.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/114099291-74738980-98ba-11eb-9eef-e1e3c5b72b4f.png" height="500"> |
|-|-|

