### PR TITLE
Fix duplicate politeia notification listener error

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/more/PoliteiaActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/more/PoliteiaActivity.kt
@@ -65,6 +65,7 @@ class PoliteiaActivity : BaseActivity(), ProposalNotificationListener,
 
     override fun onResume() {
         super.onResume()
+        multiWallet!!.politeia.removeNotificationListener(this.javaClass.name)
         multiWallet!!.politeia.addNotificationListener(this, this.javaClass.name)
     }
 


### PR DESCRIPTION
An error that causes the app to crash occurs when multiple notification listeners are added with the same key. This occurred because a notification listener added previously in the app onResume was not removed in onStop which can happen if the OS fails to call onStop. This error is avoided by removing any notification listener added with the key before adding a new
notification listener.