### PR TITLE
Disable unmixed accounts from sending to an address

### DIFF
--- a/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
@@ -95,12 +95,21 @@ class SendDialog(val fragmentActivity: FragmentActivity, dismissListener: Dialog
             // If wallet has privacy enabled, enable only mixed account when sending to an address
             // and enable all accounts when sending to an account
             val wallet = multiWallet.walletWithID(it.walletID)
-            if (wallet.readBoolConfigValueForKey(Dcrlibwallet.AccountMixerConfigSet, false)
-                    && !destinationAddressCard.isSendToAccount) {
-                it.isMixerMixedAccount
-            } else {
-                true
+            var accountIsEnabled = true // all accounts are enabled for non-privacy wallets
+            if (wallet.readBoolConfigValueForKey(Dcrlibwallet.AccountMixerConfigSet, false)) {
+                if (destinationAddressCard.isSendToAccount) {
+                    // unmixed accounts are not valid for sending if destination account is another wallet
+                    val destinationWalletID = destinationAddressCard.destinationAccount!!.walletID
+                    if (destinationWalletID != it.walletID) {
+                        accountIsEnabled = it.isMixerMixedAccount
+                    }
+                } else {
+                    // only mixed account can send to an address
+                    accountIsEnabled = it.isMixerMixedAccount
+                }
             }
+
+            accountIsEnabled
         }
         sourceAccountSpinner.pickerTitle = R.string.source_account_picker_title
 
@@ -241,6 +250,7 @@ class SendDialog(val fragmentActivity: FragmentActivity, dismissListener: Dialog
 
     private val destAccountChanged: (AccountCustomSpinner) -> Unit = {
         constructTransaction()
+        sourceAccountSpinner.refreshSelectedAccount()
     }
 
     private val destAddressChanged: () -> Unit = {

--- a/app/src/main/java/com/dcrandroid/view/util/AccountCustomSpinner.kt
+++ b/app/src/main/java/com/dcrandroid/view/util/AccountCustomSpinner.kt
@@ -7,7 +7,9 @@
 package com.dcrandroid.view.util
 
 import android.view.View
+import android.widget.Toast
 import androidx.fragment.app.FragmentManager
+import com.dcrandroid.R
 import com.dcrandroid.data.Account
 import com.dcrandroid.data.parseAccounts
 import com.dcrandroid.dialog.AccountPickerDialog
@@ -15,6 +17,7 @@ import com.dcrandroid.extensions.firstWalletWithAValidAccount
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
 import com.dcrandroid.util.CoinFormat
+import com.dcrandroid.util.SnackBar
 import com.dcrandroid.util.WalletData
 import dcrlibwallet.Wallet
 import kotlinx.android.synthetic.main.account_custom_spinner.view.*
@@ -52,6 +55,21 @@ class AccountCustomSpinner(private val fragmentManager: FragmentManager, private
     fun init(filterAccount: (account: Account) -> Boolean) {
         this.filterAccount = filterAccount
 
+        refreshSelectedAccount()
+    }
+
+    fun refreshSelectedAccount() {
+
+        var previouslySelectedAccount: Account? = null
+        if (selectedAccount != null) {
+            // don't refresh if current selected account is valid
+            if (filterAccount(selectedAccount!!)) {
+                return
+            }
+
+            previouslySelectedAccount = selectedAccount
+        }
+
         // Set default selected account as "default"
         // account from the first wallet with a valid or `walletID`
         val wal = if (singleWalletID != null) multiWallet!!.walletWithID(singleWalletID!!)
@@ -68,6 +86,11 @@ class AccountCustomSpinner(private val fragmentManager: FragmentManager, private
             }
 
             spinnerLayout.setOnClickListener(this)
+        }
+
+        if (selectedAccount != null && previouslySelectedAccount != null
+                && previouslySelectedAccount != selectedAccount) {
+            SnackBar.showText(spinnerLayout.context, R.string.source_account_changed, Toast.LENGTH_SHORT)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -456,6 +456,7 @@
     <string name="to_address">To address</string>
     <string name="paste">Paste</string>
     <string name="qr_code_scan_hint">Place QR code in the frame</string>
+    <string name="source_account_changed">Source account changed</string>
     <string name="source_account_picker_title">Sending account</string>
     <string name="dest_account_picker_title">Receiving account</string>
     <string name="none">None</string>


### PR DESCRIPTION
Previously unmixed accounts can send to any address/account except the mixed account. This change allows only the mixed account to send to an address and it is done to correlate with the way decrediton works.