### PR TITLE
Add password input delay to slow down brute force attacks

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
+++ b/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
@@ -160,21 +160,7 @@ class WalletSettings : BaseActivity() {
 
                 } catch (e: Exception) {
                     e.printStackTrace()
-
-                    if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
-                        if (dialog is PinPromptDialog) {
-                            dialog.setProcessing(false)
-                            dialog.showError()
-                        } else if (dialog is PasswordPromptDialog) {
-                            dialog.setProcessing(false)
-                            dialog.showError()
-                        }
-                    } else {
-
-                        dialog?.dismiss()
-                        Dcrlibwallet.logT(op, e.message)
-                        Utils.showErrorDialog(this@WalletSettings, op + ": " + e.message)
-                    }
+                    PassPromptUtil.handleError(this@WalletSettings, e, dialog)
                 }
             }
             false
@@ -203,19 +189,7 @@ class WalletSettings : BaseActivity() {
         } catch (e: Exception) {
             e.printStackTrace()
 
-            if (dialog is PinPromptDialog) {
-                dialog.setProcessing(false)
-            } else if (dialog is PasswordPromptDialog) {
-                dialog.setProcessing(false)
-            }
-
-            if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
-                val errMessage = when (wallet.privatePassphraseType) {
-                    Dcrlibwallet.PassphraseTypePin -> R.string.invalid_pin
-                    else -> R.string.invalid_password
-                }
-                SnackBar.showError(this@WalletSettings, errMessage)
-            }
+            PassPromptUtil.handleError(this@WalletSettings, e, dialog)
         }
     }
 

--- a/app/src/main/java/com/dcrandroid/activities/more/SettingsActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/more/SettingsActivity.kt
@@ -11,8 +11,6 @@ import android.view.ViewTreeObserver
 import com.dcrandroid.R
 import com.dcrandroid.activities.BaseActivity
 import com.dcrandroid.data.Constants
-import com.dcrandroid.dialog.PasswordPromptDialog
-import com.dcrandroid.dialog.PinPromptDialog
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
 import com.dcrandroid.fragments.PasswordPinDialogFragment
@@ -148,20 +146,7 @@ class SettingsActivity : BaseActivity(), ViewTreeObserver.OnScrollChangedListene
                     }
                 } catch (e: java.lang.Exception) {
                     e.printStackTrace()
-
-                    if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
-                        if (dialog is PinPromptDialog) {
-                            dialog.setProcessing(false)
-                            dialog.showError()
-                        } else if (dialog is PasswordPromptDialog) {
-                            dialog.setProcessing(false)
-                            dialog.showError()
-                        }
-                    } else {
-                        dialog?.dismiss()
-                        Dcrlibwallet.logT(op, e.message)
-                        Utils.showErrorDialog(this@SettingsActivity, op + ": " + e.message)
-                    }
+                    PassPromptUtil.handleError(this@SettingsActivity, e, dialog)
 
                     return@launch
                 }
@@ -213,15 +198,7 @@ class SettingsActivity : BaseActivity(), ViewTreeObserver.OnScrollChangedListene
                     }
                 } catch (e: Exception) {
                     e.printStackTrace()
-                    if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
-                        if (dialog is PinPromptDialog) {
-                            dialog.setProcessing(false)
-                            dialog.showError()
-                        } else if (dialog is PasswordPromptDialog) {
-                            dialog.setProcessing(false)
-                            dialog.showError()
-                        }
-                    }
+                    PassPromptUtil.handleError(this@SettingsActivity, e, dialog)
                 }
 
             }

--- a/app/src/main/java/com/dcrandroid/activities/privacy/AccountMixerActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/privacy/AccountMixerActivity.kt
@@ -13,8 +13,6 @@ import com.dcrandroid.R
 import com.dcrandroid.activities.BaseActivity
 import com.dcrandroid.data.Constants
 import com.dcrandroid.dialog.InfoDialog
-import com.dcrandroid.dialog.PasswordPromptDialog
-import com.dcrandroid.dialog.PinPromptDialog
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
 import com.dcrandroid.util.*
@@ -154,27 +152,13 @@ class AccountMixerActivity : BaseActivity(), AccountMixerNotificationListener, T
                 }
 
             } catch (e: Exception) {
-                if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
-                    if (dialog is PinPromptDialog) {
-                        dialog.setProcessing(false)
-                        dialog.showError()
-                    } else if (dialog is PasswordPromptDialog) {
-                        dialog.setProcessing(false)
-                        dialog.showError()
-                    }
-                } else if (e.message == Dcrlibwallet.ErrNoMixableOutput) {
+                if (e.message == Dcrlibwallet.ErrNoMixableOutput) {
                     SnackBar.showError(this, R.string.no_mixable_output)
                     GlobalScope.launch(Dispatchers.Main) {
                         dialog?.dismiss()
                     }
                 } else {
-                    GlobalScope.launch(Dispatchers.Main) {
-
-                        val op = this.javaClass.name + "startAccountMixer"
-                        dialog?.dismiss()
-                        Utils.showErrorDialog(this@AccountMixerActivity, op + ": " + e.message)
-                        Dcrlibwallet.logT(op, e.message)
-                    }
+                    PassPromptUtil.handleError(this, e, dialog)
                 }
             }
 

--- a/app/src/main/java/com/dcrandroid/activities/privacy/AccountMixerActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/privacy/AccountMixerActivity.kt
@@ -145,20 +145,22 @@ class AccountMixerActivity : BaseActivity(), AccountMixerNotificationListener, T
                 return@PassPromptUtil true
             }
 
-            try {
-                multiWallet!!.startAccountMixer(wallet.id, passphrase)
-                GlobalScope.launch(Dispatchers.Main) {
-                    dialog?.dismiss()
-                }
-
-            } catch (e: Exception) {
-                if (e.message == Dcrlibwallet.ErrNoMixableOutput) {
-                    SnackBar.showError(this, R.string.no_mixable_output)
+            GlobalScope.launch(Dispatchers.Default) {
+                try {
+                    multiWallet!!.startAccountMixer(wallet.id, passphrase)
                     GlobalScope.launch(Dispatchers.Main) {
                         dialog?.dismiss()
                     }
-                } else {
-                    PassPromptUtil.handleError(this, e, dialog)
+
+                } catch (e: Exception) {
+                    if (e.message == Dcrlibwallet.ErrNoMixableOutput) {
+                        SnackBar.showError(this@AccountMixerActivity, R.string.no_mixable_output)
+                        GlobalScope.launch(Dispatchers.Main) {
+                            dialog?.dismiss()
+                        }
+                    } else {
+                        PassPromptUtil.handleError(this@AccountMixerActivity, e, dialog)
+                    }
                 }
             }
 

--- a/app/src/main/java/com/dcrandroid/activities/verifyseed/SaveSeedActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/verifyseed/SaveSeedActivity.kt
@@ -17,19 +17,14 @@ import com.dcrandroid.R
 import com.dcrandroid.activities.BaseActivity
 import com.dcrandroid.adapter.SaveSeedAdapter
 import com.dcrandroid.data.Constants
-import com.dcrandroid.dialog.PasswordPromptDialog
-import com.dcrandroid.dialog.PinPromptDialog
 import com.dcrandroid.util.PassPromptTitle
 import com.dcrandroid.util.PassPromptUtil
-import com.dcrandroid.util.Utils
 import com.dcrandroid.util.WalletData
-import dcrlibwallet.Dcrlibwallet
 import dcrlibwallet.Wallet
 import kotlinx.android.synthetic.main.save_seed_page.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 const val SEEDS_PER_ROW = 17
 
@@ -92,21 +87,7 @@ class SaveSeedActivity : BaseActivity() {
                 } catch (e: Exception) {
                     e.printStackTrace()
 
-                    if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
-                        if (passDialog is PinPromptDialog) {
-                            passDialog.setProcessing(false)
-                            passDialog.showError()
-                        } else if (passDialog is PasswordPromptDialog) {
-                            passDialog.setProcessing(false)
-                            passDialog.showError()
-                        }
-                    } else {
-                        withContext(Dispatchers.Main) {
-                            passDialog?.dismiss()
-                            Utils.showErrorDialog(this@SaveSeedActivity, op + ": " + e.message)
-                            Dcrlibwallet.logT(op, e.message)
-                        }
-                    }
+                    PassPromptUtil.handleError(this@SaveSeedActivity, e, passDialog)
                 }
             }
 

--- a/app/src/main/java/com/dcrandroid/activities/verifyseed/VerifySeedActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/verifyseed/VerifySeedActivity.kt
@@ -16,19 +16,15 @@ import com.dcrandroid.adapter.InputSeed
 import com.dcrandroid.adapter.ShuffledSeeds
 import com.dcrandroid.adapter.VerifySeedAdapter
 import com.dcrandroid.data.Constants
-import com.dcrandroid.dialog.PasswordPromptDialog
-import com.dcrandroid.dialog.PinPromptDialog
 import com.dcrandroid.util.PassPromptTitle
 import com.dcrandroid.util.PassPromptUtil
 import com.dcrandroid.util.SnackBar
-import com.dcrandroid.util.Utils
 import dcrlibwallet.Dcrlibwallet
 import dcrlibwallet.Wallet
 import kotlinx.android.synthetic.main.verify_seed_page.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 // Step 3 for seed backup, user taps seed to verify each index.
 class VerifySeedActivity : BaseActivity() {
@@ -95,26 +91,11 @@ class VerifySeedActivity : BaseActivity() {
                 } catch (e: Exception) {
                     e.printStackTrace()
 
-                    if (passDialog is PinPromptDialog) {
-                        passDialog.setProcessing(false)
-                    } else if (passDialog is PasswordPromptDialog) {
-                        passDialog.setProcessing(false)
-                    }
-
-                    if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
-                        if (passDialog is PinPromptDialog) {
-                            passDialog.showError()
-                        } else if (passDialog is PasswordPromptDialog) {
-                            passDialog.showError()
-                        }
-                    } else if (e.message == Dcrlibwallet.ErrInvalid) {
+                    if (e.message == Dcrlibwallet.ErrInvalid) {
                         passDialog?.dismiss()
                         SnackBar.showError(this@VerifySeedActivity, R.string.seed_verification_failed)
                     } else {
-                        withContext(Dispatchers.Main) {
-                            Dcrlibwallet.logT(op, e.message)
-                            Utils.showErrorDialog(this@VerifySeedActivity, op + ": " + e.message)
-                        }
+                        PassPromptUtil.handleError(this@VerifySeedActivity, e, passDialog)
                     }
                 }
             }

--- a/app/src/main/java/com/dcrandroid/dialog/AddAccountDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/AddAccountDialog.kt
@@ -14,10 +14,8 @@ import androidx.fragment.app.FragmentActivity
 import com.dcrandroid.R
 import com.dcrandroid.util.PassPromptTitle
 import com.dcrandroid.util.PassPromptUtil
-import com.dcrandroid.util.Utils
 import com.dcrandroid.util.WalletData
 import com.dcrandroid.view.util.InputHelper
-import dcrlibwallet.Dcrlibwallet
 import dcrlibwallet.Wallet
 import kotlinx.android.synthetic.main.add_account_sheet.*
 import kotlinx.coroutines.Dispatchers
@@ -72,20 +70,8 @@ class AddAccountDialog(private val fragmentActivity: FragmentActivity, private v
                         } catch (e: Exception) {
                             e.printStackTrace()
 
+                            PassPromptUtil.handleError(fragmentActivity, e, dialog)
                             withContext(Dispatchers.Main) {
-                                dialog?.dismiss()
-
-                                if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
-                                    val err = if (wallet.privatePassphraseType == Dcrlibwallet.PassphraseTypePass) {
-                                        R.string.invalid_password
-                                    } else R.string.invalid_pin
-
-                                    accountNameInput.setError(getString(err))
-
-                                } else {
-                                    accountNameInput.setError(Utils.translateError(context!!, e))
-                                }
-
                                 setEnabled(true)
                             }
                         }

--- a/app/src/main/java/com/dcrandroid/dialog/FullScreenBottomSheetDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/FullScreenBottomSheetDialog.kt
@@ -87,6 +87,17 @@ open class FullScreenBottomSheetDialog(val dismissListener: DialogInterface.OnDi
     open fun showInfo() {}
     open fun showOptionsMenu(v: View) {}
 
+    // For password and pin dialog
+    open fun setProcessing(processing: Boolean) {
+        throw IllegalAccessException()
+    }
+
+    // For password and pin dialog
+    open fun showError() {
+        throw IllegalAccessException()
+    }
+
+
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
         dismissListener?.onDismiss(dialog)

--- a/app/src/main/java/com/dcrandroid/dialog/PasswordPromptDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/PasswordPromptDialog.kt
@@ -16,16 +16,17 @@ import com.dcrandroid.R
 import kotlinx.android.synthetic.main.password_prompt_sheet.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class PasswordPromptDialog(@StringRes val dialogTitle: Int, val isSpending: Boolean,
                            val passEntered: (dialog: FullScreenBottomSheetDialog, passphrase: String?) -> Boolean) : FullScreenBottomSheetDialog() {
 
+    var confirmed = false
+    var passwordTrials = 0
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.password_prompt_sheet, container, false)
     }
-
-    var confirmed = false
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
@@ -71,7 +72,20 @@ class PasswordPromptDialog(@StringRes val dialogTitle: Int, val isSpending: Bool
 
     override fun showError() {
         GlobalScope.launch(Dispatchers.Main) {
+            passwordTrials++
             password_input.setError(getString(R.string.invalid_password))
+            password_input.isEnabled = false
+            btn_confirm.isEnabled = false
+
+            var delayTime = 2000L
+            if (passwordTrials % 2 == 0) {
+                delayTime = 5000L
+            }
+
+            delay(delayTime)
+
+            password_input?.isEnabled = true
+            btn_confirm?.isEnabled = true
         }
     }
 

--- a/app/src/main/java/com/dcrandroid/dialog/PasswordPromptDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/PasswordPromptDialog.kt
@@ -56,19 +56,23 @@ class PasswordPromptDialog(@StringRes val dialogTitle: Int, val isSpending: Bool
         }
     }
 
-    fun setProcessing(processing: Boolean) = GlobalScope.launch(Dispatchers.Main) {
-        btn_cancel.isEnabled = !processing
-        password_input.isEnabled = !processing
+    override fun setProcessing(processing: Boolean) {
+        GlobalScope.launch(Dispatchers.Main) {
+            btn_cancel.isEnabled = !processing
+            password_input.isEnabled = !processing
 
-        if (!processing) {
-            btn_confirm.isEnabled = password_input.textString.isNotBlank()
-        } else {
-            password_input.setError(null)
+            if (!processing) {
+                btn_confirm.isEnabled = password_input.textString.isNotBlank()
+            } else {
+                password_input.setError(null)
+            }
         }
     }
 
-    fun showError() = GlobalScope.launch(Dispatchers.Main) {
-        password_input.setError(getString(R.string.invalid_password))
+    override fun showError() {
+        GlobalScope.launch(Dispatchers.Main) {
+            password_input.setError(getString(R.string.invalid_password))
+        }
     }
 
     override fun onCancel(dialog: DialogInterface) {

--- a/app/src/main/java/com/dcrandroid/dialog/PinPromptDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/PinPromptDialog.kt
@@ -62,36 +62,40 @@ class PinPromptDialog(@StringRes val dialogTitle: Int, val isSpendingPass: Boole
         }
     }
 
-    fun showError() = GlobalScope.launch(Dispatchers.Main) {
-        pinViewUtil.pinView.rejectInput = true
-        pinViewUtil.showError(R.string.invalid_pin)
-        btn_cancel.isEnabled = false
-        btn_confirm.isEnabled = false
-        btn_confirm.show()
-        progress_bar.hide()
-
-        delay(2000)
-        withContext(Dispatchers.Main) {
-            pinViewUtil.reset()
-            pinViewUtil.showHint(hint)
-            pinViewUtil.pinView.rejectInput = false
-
-            btn_cancel.isEnabled = true
-        }
-    }
-
-    fun setProcessing(processing: Boolean) = GlobalScope.launch(Dispatchers.Main) {
-        pinViewUtil.pinView.rejectInput = processing
-        btn_cancel.isEnabled = !processing
-
-        if (processing) {
-            btn_confirm.hide()
-            progress_bar.show()
-        } else {
+    override fun showError() {
+        GlobalScope.launch(Dispatchers.Main) {
+            pinViewUtil.pinView.rejectInput = true
+            pinViewUtil.showError(R.string.invalid_pin)
+            btn_cancel.isEnabled = false
+            btn_confirm.isEnabled = false
             btn_confirm.show()
             progress_bar.hide()
 
-            btn_confirm.isEnabled = pinViewUtil.passCode.isNotEmpty()
+            delay(2000)
+            withContext(Dispatchers.Main) {
+                pinViewUtil.reset()
+                pinViewUtil.showHint(hint)
+                pinViewUtil.pinView.rejectInput = false
+
+                btn_cancel.isEnabled = true
+            }
+        }
+    }
+
+    override fun setProcessing(processing: Boolean) {
+        GlobalScope.launch(Dispatchers.Main) {
+            pinViewUtil.pinView.rejectInput = processing
+            btn_cancel.isEnabled = !processing
+
+            if (processing) {
+                btn_confirm.hide()
+                progress_bar.show()
+            } else {
+                btn_confirm.show()
+                progress_bar.hide()
+
+                btn_confirm.isEnabled = pinViewUtil.passCode.isNotEmpty()
+            }
         }
     }
 

--- a/app/src/main/java/com/dcrandroid/dialog/PinPromptDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/PinPromptDialog.kt
@@ -24,6 +24,8 @@ class PinPromptDialog(@StringRes val dialogTitle: Int, val isSpendingPass: Boole
     var hint = R.string.enter_spending_pin
     private lateinit var pinViewUtil: PinViewUtil
 
+    private var pinTrials = 0
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.pin_prompt_sheet, container, false)
     }
@@ -64,6 +66,11 @@ class PinPromptDialog(@StringRes val dialogTitle: Int, val isSpendingPass: Boole
 
     override fun showError() {
         GlobalScope.launch(Dispatchers.Main) {
+            pinTrials++
+            var delayTime = 2000L
+            if (pinTrials % 2 == 0) {
+                delayTime = 5000
+            }
             pinViewUtil.pinView.rejectInput = true
             pinViewUtil.showError(R.string.invalid_pin)
             btn_cancel.isEnabled = false
@@ -71,7 +78,7 @@ class PinPromptDialog(@StringRes val dialogTitle: Int, val isSpendingPass: Boole
             btn_confirm.show()
             progress_bar.hide()
 
-            delay(2000)
+            delay(delayTime)
             withContext(Dispatchers.Main) {
                 pinViewUtil.reset()
                 pinViewUtil.showHint(hint)

--- a/app/src/main/java/com/dcrandroid/dialog/send/ConfirmTransaction.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/ConfirmTransaction.kt
@@ -17,8 +17,6 @@ import com.dcrandroid.R
 import com.dcrandroid.data.Account
 import com.dcrandroid.data.TransactionData
 import com.dcrandroid.dialog.FullScreenBottomSheetDialog
-import com.dcrandroid.dialog.PasswordPromptDialog
-import com.dcrandroid.dialog.PinPromptDialog
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
 import com.dcrandroid.util.*
@@ -111,21 +109,7 @@ class ConfirmTransaction(private val fragmentActivity: FragmentActivity, val sen
                         e.printStackTrace()
                         showSendButton()
 
-                        if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
-                            if (passDialog is PinPromptDialog) {
-                                passDialog.setProcessing(false)
-                                passDialog.showError()
-                            } else if (passDialog is PasswordPromptDialog) {
-                                passDialog.setProcessing(false)
-                                passDialog.showError()
-                            }
-                        } else {
-                            withContext(Dispatchers.Main) {
-                                passDialog?.dismiss()
-                                Dcrlibwallet.logT(op, e.message)
-                                Utils.showErrorDialog(context!!, op + ": " + e.message)
-                            }
-                        }
+                        PassPromptUtil.handleError(fragmentActivity, e, passDialog)
                     }
                 }
 

--- a/app/src/main/java/com/dcrandroid/util/ChangePassUtil.kt
+++ b/app/src/main/java/com/dcrandroid/util/ChangePassUtil.kt
@@ -10,8 +10,6 @@ import androidx.fragment.app.FragmentActivity
 import com.dcrandroid.R
 import com.dcrandroid.data.Constants
 import com.dcrandroid.dialog.FullScreenBottomSheetDialog
-import com.dcrandroid.dialog.PasswordPromptDialog
-import com.dcrandroid.dialog.PinPromptDialog
 import com.dcrandroid.fragments.PasswordPinDialogFragment
 import dcrlibwallet.Dcrlibwallet
 import kotlinx.coroutines.Dispatchers
@@ -62,21 +60,7 @@ class ChangePassUtil(private val fragmentActivity: FragmentActivity, val walletI
                         passwordPinDialogFragment.show(fragmentActivity)
                     } catch (e: Exception) {
                         e.printStackTrace()
-
-                        if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
-                            if (dialog is PinPromptDialog) {
-                                dialog.setProcessing(false)
-                                dialog.showError()
-                            } else if (dialog is PasswordPromptDialog) {
-                                dialog.setProcessing(false)
-                                dialog.showError()
-                            }
-                        } else {
-
-                            dialog?.dismiss()
-                            Dcrlibwallet.logT(op, e.message)
-                            Utils.showErrorDialog(fragmentActivity, op + ": " + e.message)
-                        }
+                        PassPromptUtil.handleError(fragmentActivity, e, dialog)
                     }
                 }
 

--- a/app/src/main/java/com/dcrandroid/util/PassPromptUtil.kt
+++ b/app/src/main/java/com/dcrandroid/util/PassPromptUtil.kt
@@ -21,25 +21,21 @@ import kotlinx.coroutines.launch
 
 data class PassPromptTitle(val passwordTitle: Int, val pinTitle: Int, val fingerprintTitle: Int = pinTitle)
 
+// return false on passEntered to keep dialog visible after tapping confirm button.
 class PassPromptUtil(private val fragmentActivity: FragmentActivity, val walletID: Long?, val title: PassPromptTitle, private val allowFingerprint: Boolean,
                      private val passEntered: (dialog: FullScreenBottomSheetDialog?, passphrase: String?) -> Boolean) {
 
     var passType: Int = Dcrlibwallet.PassphraseTypePass
 
     companion object {
-        fun handleError(activity: Activity, e: Exception, dialog: FullScreenBottomSheetDialog) {
+        fun handleError(activity: Activity, e: Exception, dialog: FullScreenBottomSheetDialog?) {
             if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
-                if (dialog is PinPromptDialog) {
-                    dialog.setProcessing(false)
-                    dialog.showError()
-                } else if (dialog is PasswordPromptDialog) {
-                    dialog.setProcessing(false)
-                    dialog.showError()
-                }
+                dialog?.setProcessing(false)
+                dialog?.showError()
             } else {
                 GlobalScope.launch(Dispatchers.Main) {
                     val op = activity.javaClass.name
-                    dialog.dismissAllowingStateLoss()
+                    dialog?.dismissAllowingStateLoss()
                     Utils.showErrorDialog(activity, op + ": " + e.message)
                     Dcrlibwallet.logT(op, e.message)
                 }


### PR DESCRIPTION
This pr adds a 5 seconds delay after every even password trial and 2 seconds delay for otherwise in an attempt to slow down a brute force attack.
Closes #538 
<img src="https://user-images.githubusercontent.com/19960200/117117266-42edc100-ad87-11eb-9e46-52c88de7c133.gif" height="500">