### PR TITLE
check if fragment is attached before attempting to display USD balance

### DIFF
--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -365,11 +365,13 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
 
         val totalBalanceAtom = multiWallet!!.totalWalletBalance()
         val totalBalanceCoin = Dcrlibwallet.amountCoin(totalBalanceAtom)
-        val formattedUSD = HtmlCompat.fromHtml(getString(R.string.usd_symbol_format, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalBalanceCoin, 2)), 0)
+        if (isAdded) {
+            val formattedUSD = HtmlCompat.fromHtml(getString(R.string.usd_symbol_format, CurrencyUtil.dcrToFormattedUSD(exchangeDecimal, totalBalanceCoin, 2)), 0)
 
-        GlobalScope.launch(Dispatchers.Main) {
-            usdBalanceTextView.text = formattedUSD
-            usdBalanceTextView.show()
+            GlobalScope.launch(Dispatchers.Main) {
+                usdBalanceTextView.text = formattedUSD
+                usdBalanceTextView.show()
+            }
         }
     }
 


### PR DESCRIPTION
Resolves https://github.com/planetdecred/dcrandroid/issues/551

This PR ensure the overview fragment has been attached before trying to display the USD balance on the overview page