### PR TITLE
keep display on for entire duration of the mixing

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/privacy/AccountMixerActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/privacy/AccountMixerActivity.kt
@@ -9,6 +9,7 @@ package com.dcrandroid.activities.privacy
 import android.content.DialogInterface
 import android.os.Bundle
 import android.text.Html
+import android.view.WindowManager
 import com.dcrandroid.BuildConfig
 import com.dcrandroid.R
 import com.dcrandroid.activities.BaseActivity
@@ -172,6 +173,10 @@ class AccountMixerActivity : BaseActivity(), AccountMixerNotificationListener, T
 
     private fun stopAccountMixer() = GlobalScope.launch(Dispatchers.Default) {
         multiWallet?.stopAccountMixer(wallet.id)
+        // Allow display to timeout after mixer is stopped
+        GlobalScope.launch(Dispatchers.Main) {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
     }
 
     override fun onAccountMixerEnded(walletID: Long) {
@@ -180,6 +185,8 @@ class AccountMixerActivity : BaseActivity(), AccountMixerNotificationListener, T
             setMixerStatus()
             GlobalScope.launch(Dispatchers.Main) {
                 mixer_toggle_switch.isChecked = false
+                // Allow display to timeout after mixer completes
+                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
             }
         }
     }
@@ -189,6 +196,8 @@ class AccountMixerActivity : BaseActivity(), AccountMixerNotificationListener, T
         setMixerStatus()
         GlobalScope.launch(Dispatchers.Main) {
             mixer_toggle_switch.isChecked = true
+            // Prevent display from timing out after mixer starts
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -569,7 +569,7 @@
     <string name="mix_tx_change">Mix transaction change</string>
     <string name="mix_tx_change_summary">Change from transactions will be sent to unmixed account if enabled.</string>
     <string name="change_sent_to_unmixed"><![CDATA[Change will be sent to <b>%1$s</b>.]]></string>
-    <string name="start_mixer_warning">Your wallet will be unlocked until mixing completes.</string>
+    <string name="start_mixer_warning">Your wallet will be unlocked and your display would remain on until mixing completes.</string>
     <string name="mixer_has_stopped_running">cspp mixer has stopped running</string>
     <string name="no_mixable_output">Unmixed account has no mixable output</string>
     <string name="new_caps">NEW</string>
@@ -596,7 +596,7 @@
     <string name="mix_server">Mix server</string>
     <string name="keep_app_opened">Keep this app opened</string>
     <string name="mixer_help_title">How to use the mixer?</string>
-    <string name="mixer_help_desc"><![CDATA[When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color="#091440">Important: keep this app opened while mixer is running.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.]]></string>
+    <string name="mixer_help_desc"><![CDATA[When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.<br/><br/><b><font color="#091440">Important: keep this app opened while mixer is running. Your display would not timeout until the mixer completes, this may impact your battery life.</font></b><br/><br/>Mixer will automatically stop when unmixed balance are fully mixed.]]></string>
     <string name="mixer_is_running">Mixer is running…</string>
     <string name="keep_this_app_opened">Keep this app opened</string>
     <string name="mixer_status_info">Mixer will automatically stop when unmixed balance are fully mixed.</string>


### PR DESCRIPTION
Resolves #550 

This PR prevent's the display from timing out while the mixer is running, and only allow the display to timeout after the mixing is completed or the mixer is cancelled

**Screenshots**
| <img src="https://user-images.githubusercontent.com/25265396/118018005-26d1bd00-b34f-11eb-885e-27ea78c9fbca.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/118017969-20dbdc00-b34f-11eb-87f5-c849839910c5.png" height="500"> |
|-|-|
