### PR TITLE
Clear the screen on flag while stopping the account mixer during privacy mixing

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/privacy/AccountMixerActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/privacy/AccountMixerActivity.kt
@@ -26,6 +26,7 @@ import kotlinx.android.synthetic.main.activity_account_mixer.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class AccountMixerActivity : BaseActivity(), AccountMixerNotificationListener, TxAndBlockNotificationListener {
 
@@ -174,7 +175,7 @@ class AccountMixerActivity : BaseActivity(), AccountMixerNotificationListener, T
     private fun stopAccountMixer() = GlobalScope.launch(Dispatchers.Default) {
         multiWallet?.stopAccountMixer(wallet.id)
         // Allow display to timeout after mixer is stopped
-        GlobalScope.launch(Dispatchers.Main) {
+        withContext(Dispatchers.Main) {
             window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
     }


### PR DESCRIPTION
properly handle the main thread in the `stopAccountMixer()` function to enable the window clear the `FLAG_KEEP_SCREEN_ON` flag