### PR TITLE
format politeia description using markwon RTF(no webview)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,6 +96,9 @@ dependencies {
     // JSON serialization & deserialization
     implementation 'com.google.code.gson:gson:2.8.6'
 
+    // Rich Text Formatting (No WebView)
+    implementation "io.noties.markwon:core:4.6.2"
+
     androidTestImplementation 'androidx.test:rules:1.4.0-alpha06'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0-alpha06'

--- a/app/src/main/java/com/dcrandroid/activities/ProposalDetailsActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/ProposalDetailsActivity.kt
@@ -12,6 +12,7 @@ import com.dcrandroid.data.Proposal
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
 import com.dcrandroid.util.Utils
+import io.noties.markwon.Markwon
 import kotlinx.android.synthetic.main.activity_proposal_details.*
 import kotlinx.android.synthetic.main.info_dialog.*
 import kotlinx.coroutines.*
@@ -77,7 +78,9 @@ class ProposalDetailsActivity : BaseActivity() {
 
         // load file from server if it is not yet loaded or outdated.
         if (proposal.indexFile!!.isNotEmpty() && proposal.indexFileVersion == proposal.version) {
-            proposal_description.text = proposal.indexFile
+            // set markdown
+            Markwon.create(this)
+                    .setMarkdown(proposal_description, proposal.indexFile!!)
         } else {
             description_progress.show()
 
@@ -88,7 +91,9 @@ class ProposalDetailsActivity : BaseActivity() {
                         val description = multiWallet!!.politeia.fetchProposalDescription(proposal.token)
                         withContext(Dispatchers.Main) {
                             description_progress?.hide()
-                            proposal_description?.text = description
+                            // set markdown
+                            Markwon.create(applicationContext)
+                                    .setMarkdown(proposal_description, description)
                         }
 
                         break


### PR DESCRIPTION
Resolves #555 

This PR ads basic rich text formatting without webview to the politeia descriptions using a third party library https://github.com/noties/Markwon

**Screenshots**
| <img src="https://user-images.githubusercontent.com/25265396/118569292-8e35a580-b771-11eb-948e-f61c002c404d.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/118569328-aad1dd80-b771-11eb-9529-37327047f143.png" height="500"> |
|-|-|

**Limitations**

Table formatting is not supported together with the basic Rich Text Formatting. In order to format a table, it would need to be done in a separate TextView/TableLayout Widget with the table alone being formatted

**Screenshots**
| <img src="https://user-images.githubusercontent.com/25265396/118570429-1157fb00-b774-11eb-9e7d-6bfab2cdac59.png" height="500">|
|-|
