### PR TITLE
update markwon implementation to include marking down tables

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,6 +98,8 @@ dependencies {
 
     // Rich Text Formatting (No WebView)
     implementation "io.noties.markwon:core:4.6.2"
+    implementation "io.noties.markwon:ext-tables:4.6.2"
+    implementation "io.noties.markwon:linkify:4.6.2"
 
     androidTestImplementation 'androidx.test:rules:1.4.0-alpha06'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'


### PR DESCRIPTION
As previously mentioned in #557 tables were not being marked down while displaying politeia proposals.

This PR adds the required implementation to support the table markdown

**Screenshots**
<img src="https://user-images.githubusercontent.com/25265396/119019929-95d59400-b995-11eb-8d4c-80966189fe06.png" width="300 "/>

