### PR TITLE
Use dcrlibwallet release-v1.5 branch for ci builds

### DIFF
--- a/dcrlibwallet-ci-build.sh
+++ b/dcrlibwallet-ci-build.sh
@@ -30,6 +30,7 @@ export DcrandroidDir=$(pwd)
 mkdir -p $GOPATH/src/github.com/planetdecred
 git clone https://github.com/planetdecred/dcrlibwallet $GOPATH/src/github.com/planetdecred/dcrlibwallet
 cd $GOPATH/src/github.com/planetdecred/dcrlibwallet
+git checkout release-v1.5
 export GO111MODULE=on && go mod vendor && export GO111MODULE=off
 gomobile bind -target=android/386
 cp dcrlibwallet.aar $DcrandroidDir/app/libs/dcrlibwallet.aar && cd $DcrandroidDir


### PR DESCRIPTION
This fixes current ci build error on release-v1.5 branch which is happening because the branch isn't compatible with dcrlibwallet master.