### PR TITLE
Disable watch only wallet in account picker

### DIFF
--- a/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
@@ -96,7 +96,8 @@ class SendDialog(val fragmentActivity: FragmentActivity, dismissListener: Dialog
             // If wallet has privacy enabled, enable only mixed account when sending to an address
             // and enable all accounts when sending to an account
             val wallet = multiWallet.walletWithID(it.walletID)
-            var accountIsEnabled = true // all accounts are enabled for non-privacy wallets
+            var accountIsEnabled = !wallet.isWatchingOnlyWallet // all accounts are enabled for non-privacy wallets
+
             if (wallet.readBoolConfigValueForKey(Dcrlibwallet.AccountMixerConfigSet, false)) {
                 if (destinationAddressCard.isSendToAccount) {
                     // unmixed accounts are not valid for sending if destination account is another wallet


### PR DESCRIPTION
This fixes a bug that allows watch-only wallets to be selected as source account when sending dcr.  

| <img src="https://user-images.githubusercontent.com/19960200/120006992-5cbea480-bfd1-11eb-8e11-e781b487f484.png" height="500"> | <img src="https://user-images.githubusercontent.com/19960200/120007012-61835880-bfd1-11eb-9923-ec79d6a889ab.png" height="500"> |
|-|-|   