### PR TITLE
Format mix transaction details

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,7 @@ android {
             buildConfigField("int", "TargetTimePerBlock", "120")
             buildConfigField("String", "LogDir", "\"/wallets/testnet3/dcrlibwallet.log\"")
             buildConfigField("String", "NetType", "\"testnet3\"")
+            buildConfigField("String", "PoliteiaHost", "\"https://test-proposals.decred.org\"")
             resValue "string", "app_name", "Decred Wallet Testnet"
             manifestPlaceholders = [
                     appIcon     : "@mipmap/ic_launcher_testnet",
@@ -58,6 +59,7 @@ android {
             buildConfigField("int", "TargetTimePerBlock", "300")
             buildConfigField("String", "LogDir", "\"/wallets/mainnet/dcrlibwallet.log\"")
             buildConfigField("String", "NetType", "\"mainnet\"")
+            buildConfigField("String", "PoliteiaHost", "\"https://proposals.decred.org\"")
             resValue "string", "app_name", "Decred Wallet"
             manifestPlaceholders = [
                     appIcon     : "@mipmap/ic_launcher_mainnet",

--- a/app/src/main/java/com/dcrandroid/HomeActivity.kt
+++ b/app/src/main/java/com/dcrandroid/HomeActivity.kt
@@ -149,7 +149,7 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
             }
             delay(6000)
             try {
-                multiWallet!!.politeia.sync()
+                multiWallet!!.politeia.sync(BuildConfig.PoliteiaHost)
             } catch (e: Exception) {
                 e.printStackTrace()
             }

--- a/app/src/main/java/com/dcrandroid/activities/ProposalDetailsActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/ProposalDetailsActivity.kt
@@ -6,12 +6,14 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.widget.NestedScrollView
+import com.dcrandroid.BuildConfig
 import com.dcrandroid.R
 import com.dcrandroid.data.Constants
 import com.dcrandroid.data.Proposal
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
 import com.dcrandroid.util.Utils
+import dcrlibwallet.Dcrlibwallet
 import io.noties.markwon.Markwon
 import io.noties.markwon.ext.tables.TableAwareMovementMethod
 import io.noties.markwon.ext.tables.TablePlugin
@@ -99,7 +101,7 @@ class ProposalDetailsActivity : BaseActivity() {
                 // keep trying to load the description while displaying any errors from the screen
                 while (true) {
                     try {
-                        val description = multiWallet!!.politeia.fetchProposalDescription(proposal.token)
+                        val description = multiWallet!!.politeia.fetchProposalDescription(BuildConfig.PoliteiaHost, proposal.token)
                         withContext(Dispatchers.Main) {
                             description_progress?.hide()
                             // set markdown

--- a/app/src/main/java/com/dcrandroid/activities/ProposalDetailsActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/ProposalDetailsActivity.kt
@@ -46,7 +46,7 @@ class ProposalDetailsActivity : BaseActivity() {
         loadProposalDetails()
 
         open_proposal.setOnClickListener {
-            val url = getString(R.string.politeia_server_url) + proposal.token
+            val url = BuildConfig.PoliteiaHost + "/record/" + proposal.token
             val i = Intent(Intent.ACTION_VIEW)
             i.data = Uri.parse(url)
             startActivity(i)
@@ -57,7 +57,7 @@ class ProposalDetailsActivity : BaseActivity() {
             share.type = getString(R.string.text_pain)
             share.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
             share.putExtra(Intent.EXTRA_SUBJECT, proposal.name)
-            share.putExtra(Intent.EXTRA_TEXT, getString(R.string.politeia_server_url) + proposal.token)
+            share.putExtra(Intent.EXTRA_TEXT, BuildConfig.PoliteiaHost + "/record/" + proposal.token)
             startActivity(Intent.createChooser(share, getString(R.string.share_proposal)))
         }
 

--- a/app/src/main/java/com/dcrandroid/activities/privacy/AccountMixerActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/privacy/AccountMixerActivity.kt
@@ -108,17 +108,19 @@ class AccountMixerActivity : BaseActivity(), AccountMixerNotificationListener, T
                 tv_mixer_status.setText(R.string.ready_to_mix)
                 tv_mixer_status.setTextColor(resources.getColor(R.color.blueGraySecondTextColor))
                 iv_mixer_status.hide()
+                mixer_toggle_switch.isEnabled = true
             } else {
                 tv_mixer_status.setText(R.string.no_mixable_output)
                 tv_mixer_status.setTextColor(resources.getColor(R.color.colorError))
                 iv_mixer_status.hide()
+                mixer_toggle_switch.isEnabled = false
             }
 
             mixing_arrow.hide()
         }
 
-        unmixed_balance.text = CoinFormat.formatAlpha(wallet.getAccountBalance(unmixedAccountNumber).total)
-        mixed_balance.text = CoinFormat.formatAlpha(wallet.getAccountBalance(mixedAccountNumber).total)
+        unmixed_balance.text = CoinFormat.formatAlpha(wallet.getAccountBalance(unmixedAccountNumber).spendable)
+        mixed_balance.text = CoinFormat.formatAlpha(wallet.getAccountBalance(mixedAccountNumber).spendable)
     }
 
     private fun showWarningAndStartMixer() {

--- a/app/src/main/java/com/dcrandroid/adapter/TransactionListAdapter.kt
+++ b/app/src/main/java/com/dcrandroid/adapter/TransactionListAdapter.kt
@@ -8,7 +8,11 @@ package com.dcrandroid.adapter
 
 import android.content.Context
 import android.graphics.Color
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.SpannableStringBuilder
 import android.text.format.DateUtils
+import android.text.style.RelativeSizeSpan
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
@@ -125,9 +129,6 @@ fun populateTxRow(transaction: Transaction, layoutRow: View, layoutInflater: Lay
     }
 
     if (transaction.type == Dcrlibwallet.TxTypeRegular) {
-        if (transaction.isMixed) {
-            layoutRow.amount.text = context.getString(R.string.mix)
-        } else {
             val txAmount = if (transaction.direction == Dcrlibwallet.TxDirectionSent) {
                 -transaction.amount
             } else {
@@ -139,10 +140,14 @@ fun populateTxRow(transaction: Transaction, layoutRow: View, layoutInflater: Lay
                 text = CoinFormat.format(strAmount + Constants.NBSP + layoutInflater.context.getString(R.string.dcr), 0.7f)
                 setTextSize(TypedValue.COMPLEX_UNIT_PX, context.resources.getDimension(R.dimen.edit_text_size_20))
             }
-        }
 
         layoutRow.ticket_price.hide()
 
+    } else if (transaction.type == Dcrlibwallet.TxTypeMixed) {
+        val amountDcrFormat = CoinFormat.formatDecred(transaction.mixDenomination)
+
+        layoutRow.amount.text = CoinFormat.format(context.getString(R.string.mixed_dcr_amount, amountDcrFormat, transaction.mixCount))
+        layoutRow.ticket_price.hide()
     } else if (Dcrlibwallet.txMatchesFilter(transaction.type, transaction.direction, Dcrlibwallet.TxFilterStaking)) {
 
         layoutRow.amount.setTextSize(TypedValue.COMPLEX_UNIT_PX, context.resources.getDimension(R.dimen.edit_text_size_18))

--- a/app/src/main/java/com/dcrandroid/adapter/TransactionListAdapter.kt
+++ b/app/src/main/java/com/dcrandroid/adapter/TransactionListAdapter.kt
@@ -8,11 +8,8 @@ package com.dcrandroid.adapter
 
 import android.content.Context
 import android.graphics.Color
-import android.text.Spannable
-import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.format.DateUtils
-import android.text.style.RelativeSizeSpan
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
@@ -34,7 +31,6 @@ import kotlinx.android.synthetic.main.transaction_row.view.*
 import java.text.SimpleDateFormat
 import java.util.*
 
-// TODO: A joint class is needed for transactions and overview pages to avoid redundancy.
 class TransactionListAdapter(val context: Context, val transactions: ArrayList<Transaction>) : RecyclerView.Adapter<TransactionListViewHolder>() {
 
     private val layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
@@ -144,10 +140,23 @@ fun populateTxRow(transaction: Transaction, layoutRow: View, layoutInflater: Lay
         layoutRow.ticket_price.hide()
 
     } else if (transaction.type == Dcrlibwallet.TxTypeMixed) {
-        val amountDcrFormat = CoinFormat.formatDecred(transaction.mixDenomination)
 
-        layoutRow.amount.text = CoinFormat.format(context.resources.getQuantityString(R.plurals.mixed_dcr_amount, transaction.mixCount, amountDcrFormat, transaction.mixCount))
-        layoutRow.ticket_price.hide()
+        var mixedAmount = CoinFormat.format(transaction.mixDenomination)
+        mixedAmount = CoinFormat.applyColor(mixedAmount, context.resources.getColor(R.color.darkBlueTextColor))
+
+        val amountBuilder = SpannableStringBuilder(mixedAmount)
+        if (transaction.mixCount > 1) {
+            amountBuilder.append("\t x${transaction.mixCount}")
+        }
+        layoutRow.ticket_price.apply {
+            show()
+            text = amountBuilder
+        }
+
+        layoutRow.amount.apply {
+            setTextSize(TypedValue.COMPLEX_UNIT_PX, context.resources.getDimension(R.dimen.edit_text_size_18))
+            setText(R.string.mixed)
+        }
     } else if (Dcrlibwallet.txMatchesFilter(transaction.type, transaction.direction, Dcrlibwallet.TxFilterStaking)) {
 
         layoutRow.amount.setTextSize(TypedValue.COMPLEX_UNIT_PX, context.resources.getDimension(R.dimen.edit_text_size_18))

--- a/app/src/main/java/com/dcrandroid/adapter/TransactionListAdapter.kt
+++ b/app/src/main/java/com/dcrandroid/adapter/TransactionListAdapter.kt
@@ -146,7 +146,7 @@ fun populateTxRow(transaction: Transaction, layoutRow: View, layoutInflater: Lay
     } else if (transaction.type == Dcrlibwallet.TxTypeMixed) {
         val amountDcrFormat = CoinFormat.formatDecred(transaction.mixDenomination)
 
-        layoutRow.amount.text = CoinFormat.format(context.getString(R.string.mixed_dcr_amount, amountDcrFormat, transaction.mixCount))
+        layoutRow.amount.text = CoinFormat.format(context.resources.getQuantityString(R.plurals.mixed_dcr_amount, transaction.mixCount, amountDcrFormat, transaction.mixCount))
         layoutRow.ticket_price.hide()
     } else if (Dcrlibwallet.txMatchesFilter(transaction.type, transaction.direction, Dcrlibwallet.TxFilterStaking)) {
 

--- a/app/src/main/java/com/dcrandroid/data/Transaction.kt
+++ b/app/src/main/java/com/dcrandroid/data/Transaction.kt
@@ -44,9 +44,6 @@ class Transaction : Serializable {
     @SerializedName("timestamp")
     var timestamp: Long = 0
 
-    @SerializedName("is_mixed")
-    var isMixed: Boolean = false
-
     @SerializedName("mix_denom")
     var mixDenomination: Long = 0
 
@@ -111,6 +108,8 @@ class Transaction : Serializable {
                     else -> R.drawable.ic_ticket_revoked
                 }
 
+            }else if (type == Dcrlibwallet.TxTypeMixed){
+                res = R.drawable.ic_mixed
             }
 
             return res

--- a/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
@@ -390,7 +390,7 @@ class SendDialog(val fragmentActivity: FragmentActivity, dismissListener: Dialog
         val feeAndSize: TxFeeAndSize
 
         try {
-            txAuthor = multiWallet.newUnsignedTx(sourceAccountSpinner.wallet, selectedAccount.accountNumber)
+            txAuthor = multiWallet.newUnsignedTx(sourceAccountSpinner.wallet.id, selectedAccount.accountNumber)
             txAuthor.addSendDestination(destinationAddressCard.estimationAddress, amountAtom, sendMax)
             feeAndSize = txAuthor.estimateFeeAndSize()
         } catch (e: Exception) {

--- a/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
@@ -54,7 +54,8 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
 
         if (transaction.type == Dcrlibwallet.TxTypeMixed) {
             val amountDcrFormat = CoinFormat.formatDecred(transaction.mixDenomination)
-            tx_details_amount.text = CoinFormat.format(getString(R.string.mixed_dcr_amount, amountDcrFormat, transaction.mixCount))
+
+            tx_details_amount.text = CoinFormat.format(resources.getQuantityString(R.plurals.mixed_dcr_amount, transaction.mixCount, amountDcrFormat, transaction.mixCount))
         } else {
             val txAmount = if (transaction.direction == Dcrlibwallet.TxDirectionSent && transaction.type == Dcrlibwallet.TxTypeRegular) {
                 -transaction.amount

--- a/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
@@ -9,6 +9,8 @@ package com.dcrandroid.dialog.txdetails
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.view.LayoutInflater
 import android.view.View
@@ -56,7 +58,9 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
 
             val amountBuilder = SpannableStringBuilder(amountDcrFormat)
             if (transaction.mixCount > 1) {
-                amountBuilder.append("\t x${transaction.mixCount}")
+                var mixCount = SpannableString("\t x${transaction.mixCount}") as Spannable
+                mixCount = CoinFormat.applyColor(mixCount, context!!.resources.getColor(R.color.lightGrayTextColor))
+                amountBuilder.append(mixCount)
             }
 
             tx_details_amount.text = amountBuilder

--- a/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
@@ -9,7 +9,6 @@ package com.dcrandroid.dialog.txdetails
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.view.LayoutInflater
 import android.view.View
@@ -53,9 +52,14 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
         tx_details_icon.setImageResource(transaction.iconResource)
 
         if (transaction.type == Dcrlibwallet.TxTypeMixed) {
-            val amountDcrFormat = CoinFormat.formatDecred(transaction.mixDenomination)
+            val amountDcrFormat = CoinFormat.format(transaction.mixDenomination)
 
-            tx_details_amount.text = CoinFormat.format(resources.getQuantityString(R.plurals.mixed_dcr_amount, transaction.mixCount, amountDcrFormat, transaction.mixCount))
+            val amountBuilder = SpannableStringBuilder(amountDcrFormat)
+            if (transaction.mixCount > 1) {
+                amountBuilder.append("\t x${transaction.mixCount}")
+            }
+
+            tx_details_amount.text = amountBuilder
         } else {
             val txAmount = if (transaction.direction == Dcrlibwallet.TxDirectionSent && transaction.type == Dcrlibwallet.TxTypeRegular) {
                 -transaction.amount

--- a/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
@@ -9,6 +9,8 @@ package com.dcrandroid.dialog.txdetails
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.text.SpannableString
+import android.text.SpannableStringBuilder
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -28,6 +30,7 @@ import com.dcrandroid.util.SnackBar
 import com.dcrandroid.util.Utils
 import dcrlibwallet.Dcrlibwallet
 import kotlinx.android.synthetic.main.transaction_details.*
+import kotlinx.android.synthetic.main.transaction_row.view.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -49,8 +52,9 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
 
         tx_details_icon.setImageResource(transaction.iconResource)
 
-        if (transaction.isMixed) {
-            tx_details_amount.text = CoinFormat.format(transaction.mixDenomination, 0.625f)
+        if (transaction.type == Dcrlibwallet.TxTypeMixed) {
+            val amountDcrFormat = CoinFormat.formatDecred(transaction.mixDenomination)
+            tx_details_amount.text = CoinFormat.format(getString(R.string.mixed_dcr_amount, amountDcrFormat, transaction.mixCount))
         } else {
             val txAmount = if (transaction.direction == Dcrlibwallet.TxDirectionSent && transaction.type == Dcrlibwallet.TxTypeRegular) {
                 -transaction.amount
@@ -94,11 +98,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
                             tx_details_dest.setOnClickListener(this@TransactionDetailsDialog)
                         }
 
-                        if (transaction.isMixed) {
-                            toolbar_title.setText(R.string.mix)
-                        } else {
-                            toolbar_title.setText(R.string.sent)
-                        }
+                        toolbar_title.setText(R.string.sent)
                     }
                     Dcrlibwallet.TxDirectionReceived -> {
                         tx_source_row.show()
@@ -122,6 +122,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
                     Dcrlibwallet.TxTypeTicketPurchase -> R.string.ticket_purchase
                     Dcrlibwallet.TxTypeVote -> R.string.vote
                     Dcrlibwallet.TxTypeRevocation -> R.string.revoked
+                    Dcrlibwallet.TxTypeMixed -> R.string.mixed
                     else -> R.string.tx_sort_coinbase
                 }
 

--- a/app/src/main/java/com/dcrandroid/fragments/TransactionsFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/TransactionsFragment.kt
@@ -123,10 +123,12 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
     private fun refreshAvailableTxType() = GlobalScope.launch(Dispatchers.Default) {
         availableTxTypes.clear()
 
+        // TODO
         val txCount = wallet!!.countTransactions(Dcrlibwallet.TxFilterAll)
         val sentTxCount = wallet!!.countTransactions(Dcrlibwallet.TxFilterSent)
         val receivedTxCount = wallet!!.countTransactions(Dcrlibwallet.TxFilterReceived)
         val transferredTxCount = wallet!!.countTransactions(Dcrlibwallet.TxFilterTransferred)
+        val mixedTxCount = wallet!!.countTransactions(Dcrlibwallet.TxFilterMixed)
         val stakingTxCount = wallet!!.countTransactions(Dcrlibwallet.TxFilterStaking)
         val coinbaseTxCount = wallet!!.countTransactions(Dcrlibwallet.TxFilterCoinBase)
 
@@ -139,6 +141,7 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
             availableTxTypes.add(context!!.getString(R.string.tx_sort_sent, sentTxCount))
             availableTxTypes.add(context!!.getString(R.string.tx_sort_received, receivedTxCount))
             availableTxTypes.add(context!!.getString(R.string.tx_sort_transferred, transferredTxCount))
+            availableTxTypes.add(context!!.getString(R.string.tx_sort_mixed, mixedTxCount))
 
             if (stakingTxCount > 0) {
                 availableTxTypes.add(context!!.getString(R.string.tx_sort_staking, stakingTxCount))
@@ -300,6 +303,7 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
                 1 -> Dcrlibwallet.TxFilterSent
                 2 -> Dcrlibwallet.TxFilterReceived
                 3 -> Dcrlibwallet.TxFilterTransferred
+                4 -> Dcrlibwallet.TxFilterMixed
                 else -> Dcrlibwallet.TxFilterStaking
             }
 

--- a/app/src/main/java/com/dcrandroid/util/CoinFormat.kt
+++ b/app/src/main/java/com/dcrandroid/util/CoinFormat.kt
@@ -12,6 +12,7 @@ import android.text.SpannableString
 import android.text.style.CharacterStyle
 import android.text.style.ForegroundColorSpan
 import android.text.style.RelativeSizeSpan
+import androidx.annotation.ColorInt
 import dcrlibwallet.Dcrlibwallet
 import java.text.DecimalFormat
 import java.text.NumberFormat
@@ -32,6 +33,13 @@ object CoinFormat {
     fun formatRelative(spannable: Spannable, relativeSize: Float = 0.7f): Spannable {
         val span = RelativeSizeSpan(relativeSize)
         return formatSpannable(spannable, span)
+    }
+
+    fun applyColor(spannable: Spannable, @ColorInt color: Int): Spannable {
+        val span = ForegroundColorSpan(color)
+
+        spannable.setSpan(span, 0, spannable.length, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+        return spannable
     }
 
     fun formatAlpha(dcr: Long): Spannable {
@@ -76,7 +84,7 @@ object CoinFormat {
             return spannable
         }
 
-        spannable.setSpan(span, startIndex, spannable.length, Spannable.SPAN_INCLUSIVE_INCLUSIVE)
+        spannable.setSpan(span, startIndex, spannable.length, Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
         return spannable
     }
 

--- a/app/src/main/res/drawable/ic_mixed.xml
+++ b/app/src/main/res/drawable/ic_mixed.xml
@@ -1,0 +1,12 @@
+<vector android:height="24dp" android:viewportHeight="22"
+    android:viewportWidth="22" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#1b41b3" android:pathData="M1.222,9.778h15.889v8.556h-15.889z"/>
+    <path android:fillColor="#66a9ff" android:pathData="M4.889,3.667h15.889v8.556h-15.889z"/>
+    <path android:fillColor="#1b41b3" android:pathData="M8.1728,6.415L12.0018,6.415A0.665,0.665 0,0 1,12.6668 7.08L12.6668,9.189A0.665,0.665 0,0 1,12.0018 9.854L8.1728,9.854A0.665,0.665 0,0 1,7.5078 9.189L7.5078,7.08A0.665,0.665 0,0 1,8.1728 6.415z"/>
+    <path android:fillColor="#1b41b3" android:pathData="M14.478,6.415L18.307,6.415A0.665,0.665 0,0 1,18.972 7.08L18.972,9.189A0.665,0.665 0,0 1,18.307 9.854L14.478,9.854A0.665,0.665 0,0 1,13.813 9.189L13.813,7.08A0.665,0.665 0,0 1,14.478 6.415z"/>
+    <path android:fillColor="#1b41b3" android:pathData="M6.9351,6.415h1.146v0.573h-1.146z"/>
+    <path android:fillColor="#1b41b3" android:pathData="M18.3989,6.415h1.146v0.573h-1.146z"/>
+    <path android:fillColor="#1b41b3" android:pathData="M11.6421,6.9883h3.226v0.573h-3.226z"/>
+    <path android:fillColor="#66a9ff" android:pathData="M8.7988,9.3476a0.916,0.916 0,0 1,-0.915 -0.915h0.459a0.456,0.456 0,0 0,0.456 0.456Z"/>
+    <path android:fillColor="#66a9ff" android:pathData="M15.0722,9.3476a0.916,0.916 0,0 1,-0.915 -0.915h0.458a0.457,0.457 0,0 0,0.457 0.456Z"/>
+</vector>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -644,7 +644,6 @@
     <string name="new_proposal">新的提案</string>
     <string name="vote_started">投票已开始</string>
     <string name="vote_ended">投票已结束</string>
-    <string name="politeia_server_url" translatable="false">http://proposals.decred.org/proposals/</string>
     <string name="share_proposal">分享提案链接</string>
     <string name="text_pain" translatable="false">text/plain</string>
     <string name="comments">%d 评论</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,7 +69,6 @@
     <string name="create">Create</string>
     <string name="_import">Import</string>
     <string name="dcr_amount">%1$s DCR</string>
-    <string name="mixed_dcr_amount">%1$s DCR\t x%2$d</string>
     <string name="rename_wallet_sheet_title">Rename wallet</string>
     <string name="wallet_name">Wallet Name</string>
     <string name="privacy">Privacy</string>
@@ -80,6 +79,11 @@
     <string name="remove_watch_wallet_prompt"> Remove watch-only wallet from device?</string>
     <string name="remove_wallet_message">Make sure to have the seed phrase backed up before removing the wallet.</string>
     <string name="error_copied">Error copied</string>
+
+    <plurals name="mixed_dcr_amount">
+        <item quantity="one">%1$s DCR</item>
+        <item quantity="other">%1$s DCR\t x%2$d</item>
+    </plurals>
     <!--/General-->
 
     <!--Peers-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -408,6 +408,7 @@
     <string name="tx_sort_sent">Sent (%1$d)</string>
     <string name="tx_sort_received">Received (%1$d)</string>
     <string name="tx_sort_transferred">Transferred (%1$d)</string>
+    <string name="tx_sort_mixed">Mixed (%1$d)</string>
     <string name="tx_sort_staking">Staking (%1$d)</string>
     <string name="tx_sort_coinbase">Coinbase (%1$d)</string>
     <string name="ticket_purchase">Ticket Purchase</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -650,7 +650,6 @@
     <string name="new_proposal">New Proposal</string>
     <string name="vote_started">Vote Started</string>
     <string name="vote_ended">Vote Ended</string>
-    <string name="politeia_server_url" translatable="false">http://proposals.decred.org/proposals/</string>
     <string name="share_proposal">Share Proposal Link</string>
     <string name="text_pain" translatable="false">text/plain</string>
     <string name="comments">%d comments</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
     <string name="create">Create</string>
     <string name="_import">Import</string>
     <string name="dcr_amount">%1$s DCR</string>
+    <string name="mixed_dcr_amount">%1$s DCR\t x%2$d</string>
     <string name="rename_wallet_sheet_title">Rename wallet</string>
     <string name="wallet_name">Wallet Name</string>
     <string name="privacy">Privacy</string>
@@ -566,6 +567,7 @@
     <string name="unmixed_account">Unmixed account</string>
     <string name="mixer">Mixer</string>
     <string name="mix">Mix</string>
+    <string name="mixed">Mixed</string>
     <string name="mix_tx_change">Mix transaction change</string>
     <string name="mix_tx_change_summary">Change from transactions will be sent to unmixed account if enabled.</string>
     <string name="change_sent_to_unmixed"><![CDATA[Change will be sent to <b>%1$s</b>.]]></string>


### PR DESCRIPTION
This change adds the icon and mixed count to mix transaction row and dialog.
Closes #562 & #563 Requires https://github.com/planetdecred/dcrlibwallet/pull/195  

| <img src="https://user-images.githubusercontent.com/19960200/120557636-22e90600-c3f6-11eb-83b4-ec66ae276a60.png" height="500"> | <img src="https://user-images.githubusercontent.com/19960200/120557650-28465080-c3f6-11eb-8997-a7f43c3bd592.png" height="500"> |
|-|-|   
