### PR TITLE
add a navigation bar to the license page

### DIFF
--- a/app/src/main/java/com/dcrandroid/HomeActivity.kt
+++ b/app/src/main/java/com/dcrandroid/HomeActivity.kt
@@ -21,7 +21,6 @@ import android.os.Handler
 import android.util.DisplayMetrics
 import android.view.MotionEvent
 import android.view.View
-import android.view.WindowManager
 import android.view.animation.AnimationUtils
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -58,7 +57,7 @@ import kotlin.system.exitProcess
 
 const val TAG = "HomeActivity"
 
-class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificationListener, ProposalNotificationListener, AccountMixerNotificationListener {
+class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificationListener, ProposalNotificationListener {
 
     private var deviceWidth: Int = 0
     private var blockNotificationSound: Int = 0
@@ -154,8 +153,6 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
                 e.printStackTrace()
             }
         }
-
-        checkMixerStatus()
     }
 
     private val bottomSheetDismissed = DialogInterface.OnDismissListener {
@@ -177,32 +174,8 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
         }
     }
 
-    private fun checkMixerStatus() = GlobalScope.launch(Dispatchers.Main) {
-        var activeMixers = 0
-        for (wallet in multiWallet!!.openedWalletsList()) {
-            if (wallet.isAccountMixerActive) {
-                activeMixers++
-            }
-        }
-
-        if (activeMixers > 0) {
-            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        } else {
-            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        }
-    }
-
-    override fun onAccountMixerEnded(walletID: Long) {
-        checkMixerStatus()
-    }
-
-    override fun onAccountMixerStarted(walletID: Long) {
-        checkMixerStatus()
-    }
-
     override fun onResume() {
         super.onResume()
-        checkMixerStatus()
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/dcrandroid/activities/BaseActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/BaseActivity.kt
@@ -76,7 +76,14 @@ open class BaseActivity : AppCompatActivity(), AccountMixerNotificationListener 
 
     override fun onResume() {
         super.onResume()
+        multiWallet!!.removeAccountMixerNotificationListener(this.javaClass.name)
+        multiWallet!!.addAccountMixerNotificationListener(this, this.javaClass.name)
         checkMixerStatus()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        multiWallet!!.removeAccountMixerNotificationListener(this.javaClass.name)
     }
 
     override fun onAccountMixerEnded(walletID: Long) {

--- a/app/src/main/java/com/dcrandroid/activities/BaseActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/BaseActivity.kt
@@ -17,11 +17,16 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import com.dcrandroid.extensions.openedWalletsList
 import com.dcrandroid.util.WalletData
+import dcrlibwallet.AccountMixerNotificationListener
 import dcrlibwallet.MultiWallet
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 @SuppressLint("Registered")
-open class BaseActivity : AppCompatActivity() {
+open class BaseActivity : AppCompatActivity(), AccountMixerNotificationListener {
 
     internal val walletData: WalletData = WalletData.instance
     internal val multiWallet: MultiWallet?
@@ -36,6 +41,8 @@ open class BaseActivity : AppCompatActivity() {
         } else {
             window.navigationBarColor = ContextCompat.getColor(this, android.R.color.black)
         }
+
+        checkMixerStatus()
     }
 
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
@@ -50,5 +57,33 @@ open class BaseActivity : AppCompatActivity() {
                 (this.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(this.window.decorView.applicationWindowToken, 0)
         }
         return super.dispatchTouchEvent(ev)
+    }
+
+    private fun checkMixerStatus() = GlobalScope.launch(Dispatchers.Main) {
+        var activeMixers = 0
+        for (wallet in multiWallet!!.openedWalletsList()) {
+            if (wallet.isAccountMixerActive) {
+                activeMixers++
+            }
+        }
+
+        if (activeMixers > 0) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        checkMixerStatus()
+    }
+
+    override fun onAccountMixerEnded(walletID: Long) {
+        checkMixerStatus()
+    }
+
+    override fun onAccountMixerStarted(walletID: Long) {
+        checkMixerStatus()
     }
 }

--- a/app/src/main/java/com/dcrandroid/activities/License.kt
+++ b/app/src/main/java/com/dcrandroid/activities/License.kt
@@ -9,6 +9,7 @@ package com.dcrandroid.activities
 import android.os.Bundle
 import android.widget.TextView
 import com.dcrandroid.R
+import kotlinx.android.synthetic.main.activity_license.*
 
 class License : BaseActivity() {
     val license = "ISC License" +
@@ -32,5 +33,7 @@ class License : BaseActivity() {
 
         setContentView(R.layout.activity_license)
         findViewById<TextView>(R.id.license_text).text = license
+
+        go_back.setOnClickListener { finish() }
     }
 }

--- a/app/src/main/java/com/dcrandroid/activities/privacy/AccountMixerActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/privacy/AccountMixerActivity.kt
@@ -36,7 +36,10 @@ class AccountMixerActivity : BaseActivity(), AccountMixerNotificationListener, T
 
     override fun onResume() {
         super.onResume()
+        multiWallet!!.removeTxAndBlockNotificationListener(this.javaClass.name)
         multiWallet!!.addTxAndBlockNotificationListener(this, this.javaClass.name)
+        multiWallet!!.removeAccountMixerNotificationListener(this.javaClass.name)
+        multiWallet!!.addAccountMixerNotificationListener(this, this.javaClass.name)
         setMixerStatus()
     }
 
@@ -58,8 +61,6 @@ class AccountMixerActivity : BaseActivity(), AccountMixerNotificationListener, T
 
         mixed_account_label.text = wallet.accountName(mixedAccountNumber)
         unmixed_account_label.text = wallet.accountName(unmixedAccountNumber)
-
-        multiWallet?.setAccountMixerNotification(this@AccountMixerActivity)
 
         if (wallet.isAccountMixerActive) {
             mixer_toggle_switch.isChecked = true
@@ -90,6 +91,7 @@ class AccountMixerActivity : BaseActivity(), AccountMixerNotificationListener, T
 
     override fun onPause() {
         super.onPause()
+        multiWallet!!.removeAccountMixerNotificationListener(this.javaClass.name)
         multiWallet!!.removeTxAndBlockNotificationListener(this.javaClass.name)
     }
 

--- a/app/src/main/java/com/dcrandroid/fragments/BaseFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/BaseFragment.kt
@@ -6,20 +6,15 @@
 
 package com.dcrandroid.fragments
 
-import android.view.WindowManager
 import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import com.dcrandroid.HomeActivity
 import com.dcrandroid.data.Transaction
-import com.dcrandroid.extensions.openedWalletsList
 import com.dcrandroid.util.WalletData
 import com.google.gson.Gson
 import dcrlibwallet.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 
-open class BaseFragment : Fragment(), SyncProgressListener, TxAndBlockNotificationListener, AccountMixerNotificationListener {
+open class BaseFragment : Fragment(), SyncProgressListener, TxAndBlockNotificationListener {
 
     var TAG = this.javaClass.name
     var isForeground = false
@@ -36,8 +31,6 @@ open class BaseFragment : Fragment(), SyncProgressListener, TxAndBlockNotificati
 
         multiWallet?.addSyncProgressListener(this, TAG)
         multiWallet?.addTxAndBlockNotificationListener(this, TAG)
-
-        checkMixerStatus()
     }
 
     override fun onResume() {
@@ -47,7 +40,6 @@ open class BaseFragment : Fragment(), SyncProgressListener, TxAndBlockNotificati
             requiresDataUpdate = false
             onTxOrBalanceUpdateRequired(null)
         }
-        checkMixerStatus()
     }
 
     override fun onPause() {
@@ -59,29 +51,6 @@ open class BaseFragment : Fragment(), SyncProgressListener, TxAndBlockNotificati
         super.onDestroy()
         multiWallet?.removeSyncProgressListener(TAG)
         multiWallet?.removeTxAndBlockNotificationListener(TAG)
-    }
-
-    private fun checkMixerStatus() = GlobalScope.launch(Dispatchers.Main) {
-        var activeMixers = 0
-        for (wallet in multiWallet!!.openedWalletsList()) {
-            if (wallet.isAccountMixerActive) {
-                activeMixers++
-            }
-        }
-
-        if (activeMixers > 0) {
-            requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        } else {
-            requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        }
-    }
-
-    override fun onAccountMixerEnded(walletID: Long) {
-        checkMixerStatus()
-    }
-
-    override fun onAccountMixerStarted(walletID: Long) {
-        checkMixerStatus()
     }
 
     fun setToolbarTitle(title: CharSequence, showShadow: Boolean) {

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -8,10 +8,7 @@ package com.dcrandroid.fragments
 
 import android.content.DialogInterface
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import android.view.ViewTreeObserver
+import android.view.*
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.text.HtmlCompat
@@ -171,8 +168,10 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
             tv_mixer_running.text = context!!.resources.getQuantityString(R.plurals.mixer_is_running, activeMixers, activeMixers)
             cspp_running_layout.show()
             mixer_status_rv.adapter?.notifyDataSetChanged()
+            requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         } else {
             cspp_running_layout.hide()
+            requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
 
         mixer_go_to_wallets.setOnClickListener {

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -146,7 +146,6 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
         mixer_status_rv.layoutManager = LinearLayoutManager(context)
         mixer_status_rv.adapter = MixerStatusAdapter()
         setMixerStatus()
-        multiWallet?.setAccountMixerNotification(this)
 
         fetchExchangeRate()
     }
@@ -168,10 +167,8 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
             tv_mixer_running.text = context!!.resources.getQuantityString(R.plurals.mixer_is_running, activeMixers, activeMixers)
             cspp_running_layout.show()
             mixer_status_rv.adapter?.notifyDataSetChanged()
-            requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         } else {
             cspp_running_layout.hide()
-            requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
 
         mixer_go_to_wallets.setOnClickListener {
@@ -181,6 +178,8 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
 
     override fun onResume() {
         super.onResume()
+        multiWallet!!.removeAccountMixerNotificationListener(this.javaClass.name)
+        multiWallet!!.addAccountMixerNotificationListener(this, this.javaClass.name)
         syncLayoutUtil = SyncLayoutUtil(syncLayout, { restartSyncProcess() }, {
             if (multiWallet!!.isSyncing) {
                 scrollView.postDelayed({
@@ -192,6 +191,7 @@ class OverviewFragment : BaseFragment(), ViewTreeObserver.OnScrollChangedListene
 
     override fun onPause() {
         super.onPause()
+        multiWallet!!.removeAccountMixerNotificationListener(this.javaClass.name)
         syncLayoutUtil?.destroy()
         syncLayoutUtil = null
     }

--- a/app/src/main/res/layout/activity_license.xml
+++ b/app/src/main/res/layout/activity_license.xml
@@ -7,15 +7,77 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:padding="3dp"
-    android:scrollbarAlwaysDrawHorizontalTrack="true"
-    tools:context="com.dcrandroid.activities.License">
+    android:layout_height="match_parent"
+    android:background="@color/colorBackground"
+    tools:context="com.dcrandroid.activities.License"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="?actionBarSize"
+        android:id="@+id/app_bar"
+        app:elevation="0dp"
+        android:background="@color/colorBackground"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingStart="0dp"
+            android:paddingLeft="0dp"
+            app:contentInsetStart="0dp"
+            app:contentInsetLeft="0dp"
+            android:paddingEnd="0dp"
+            android:paddingRight="0dp"
+            app:contentInsetEnd="0dp"
+            app:contentInsetRight="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:paddingStart="@dimen/margin_padding_size_8"
+                android:paddingEnd="0dp"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <ImageView
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:padding="@dimen/margin_padding_size_8"
+                    android:background="@drawable/bg_primary_ripple"
+                    android:focusable="true"
+                    android:clickable="true"
+                    android:id="@+id/go_back"
+                    app:srcCompat="@drawable/ic_back" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/license"
+                    android:layout_marginStart="@dimen/margin_padding_size_8"
+                    android:textSize="@dimen/edit_text_size_20"
+                    android:textColor="@color/darkBlueTextColor"
+                    android:includeFontPadding="false"
+                    app:fontFamily="@font/source_sans_pro" />
+
+            </LinearLayout>
+
+        </androidx.appcompat.widget.Toolbar>
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.appcompat.widget.AppCompatTextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingStart="@dimen/margin_padding_size_16"
+        android:paddingEnd="@dimen/margin_padding_size_16"
+        android:layout_marginTop="@dimen/margin_padding_size_8"
+        android:fontFamily="@font/source_sans_pro"
+        android:textSize="@dimen/edit_text_size_14"
+        android:textColor="@color/darkerBlueGrayTextColor"
         android:scrollbars="vertical"
         android:id="@+id/license_text" />
 


### PR DESCRIPTION
Requires https://github.com/planetdecred/dcrlibwallet/pull/198

Resolves #564 

This PR resolves the follwing;

1. add a navigation bar to license page
2. The functionality to keep the screen on during mixing was moved from the HomeActivity into the BaseActivity, since all activities extend the BaseActivity, it ensures all activities have access to the Account Mixer callback listeners

**Screenshots**

<img src="https://user-images.githubusercontent.com/25265396/120370485-8860c800-c30c-11eb-88c4-b0be5178e140.png" width="300" />
