### PR TITLE
add info icon to explain transaction byte size

### DIFF
--- a/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
@@ -10,6 +10,7 @@ import android.app.Activity.RESULT_OK
 import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
+import android.text.Html
 import android.text.SpannableString
 import android.text.Spanned
 import android.view.LayoutInflater
@@ -140,6 +141,13 @@ class SendDialog(
         iv_send_max.setOnClickListener {
             sendMax = true
             constructTransaction()
+        }
+        iv_tx_info.setOnClickListener {
+            InfoDialog(requireContext())
+                    .setDialogTitle(getString(R.string.transaction_size))
+                    .setMessage(Html.fromHtml(getString(R.string.tx_size_info)))
+                    .setPositiveButton(getString(R.string.got_it), null)
+                    .show()
         }
 
         send_next.setOnClickListener {

--- a/app/src/main/res/layout/fee_layout.xml
+++ b/app/src/main/res/layout/fee_layout.xml
@@ -130,15 +130,31 @@
             android:layout_marginTop="16dp"
             android:orientation="horizontal">
 
-            <TextView
+            <LinearLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="@string/transaction_size"
-                android:textColor="@color/text4"
-                android:textSize="14sp"
-                android:includeFontPadding="false"
-                app:fontFamily="@font/source_sans_pro" />
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/transaction_size"
+                    android:textColor="@color/text4"
+                    android:textSize="14sp"
+                    android:includeFontPadding="false"
+                    app:fontFamily="@font/source_sans_pro" />
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:id="@+id/iv_tx_info"
+                    android:padding="@dimen/margin_padding_size_8"
+                    android:layout_marginStart="@dimen/margin_padding_size_8"
+                    android:background="@drawable/ic_info"
+                    app:srcCompat="@drawable/ic_close" />
+
+            </LinearLayout>
 
             <TextView
                 android:id="@+id/tx_size"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -640,6 +640,7 @@
     <string name="age">Age</string>
     <string name="maturity">Maturity</string>
     <string name="verify_seed_header_instruction">Select the correct words to verify.</string>
+    <string name="tx_size_info"><![CDATA[Transaction size is determined by how many inputs and outputs are required to fulfill a transaction.<br/><br/>Typically, larger quantities transacted require larger transaction sizes, which in turn create larger transaction fees.]]></string>
     <plurals name="mixer_is_running">
         <item quantity="one">1 mixer is running…</item>
         <item quantity="other">%d mixers are running…</item>


### PR DESCRIPTION
Resolves #265

This PR adds an info icon that explains how the transaction byte size is determined

**Screenshots**

| <img src="https://user-images.githubusercontent.com/25265396/143285304-b0401d07-b8e2-463a-82aa-41e0c02aee5e.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/143286401-143f5e6b-81ea-4060-96da-446617e5a020.png" height="500"> |
|-|-|
