### PR TITLE
fix dark mode bugs

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/BaseActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/BaseActivity.kt
@@ -20,6 +20,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
 import com.dcrandroid.data.Constants
 import com.dcrandroid.extensions.openedWalletsList
+import com.dcrandroid.preference.PreferenceHelper
 import com.dcrandroid.util.WalletData
 import dcrlibwallet.AccountMixerNotificationListener
 import dcrlibwallet.MultiWallet
@@ -36,8 +37,11 @@ open class BaseActivity : AppCompatActivity(), AccountMixerNotificationListener 
     internal val walletData: WalletData = WalletData.instance
     internal val multiWallet: MultiWallet?
         get() = walletData.multiWallet
+    var preferenceHelper: PreferenceHelper? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        preferenceHelper = PreferenceHelper()
+        preferenceHelper!!.PreferenceHelper(this)
         setColorTheme()
         super.onCreate(savedInstanceState)
 
@@ -74,7 +78,11 @@ open class BaseActivity : AppCompatActivity(), AccountMixerNotificationListener 
             }
 
         } else {
-            lastDayNightMode = AppCompatDelegate.getDefaultNightMode()
+            val colorTheme = preferenceHelper?.getInt(Constants.COLOR_THEME, Constants.DEF_COLOR_THEME)
+            if (colorTheme != null) {
+                lastDayNightMode = nightMode(colorTheme)
+                AppCompatDelegate.setDefaultNightMode(lastDayNightMode)
+            }
         }
     }
 

--- a/app/src/main/java/com/dcrandroid/preference/ListPreference.kt
+++ b/app/src/main/java/com/dcrandroid/preference/ListPreference.kt
@@ -19,6 +19,7 @@ import androidx.annotation.ArrayRes
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.dcrandroid.R
+import com.dcrandroid.data.Constants
 import kotlinx.android.synthetic.main.activity_debug.view.*
 import kotlinx.android.synthetic.main.list_preference_dialog.*
 import kotlinx.android.synthetic.main.list_preference_row.view.*
@@ -41,6 +42,8 @@ class ListPreference(
 
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
+            val preferenceHelper = PreferenceHelper()
+            preferenceHelper.PreferenceHelper(context)
             requestWindowFeature(Window.FEATURE_NO_TITLE)
             window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
             setContentView(R.layout.list_preference_dialog)
@@ -57,6 +60,9 @@ class ListPreference(
             btn_negative.setOnClickListener { dismiss() }
             btn_positive.setOnClickListener {
                 multiWallet!!.setInt32ConfigValueForKey(key, adapter.selectedItem)
+                if (key == Constants.COLOR_THEME) {
+                    preferenceHelper.putInt(key, adapter.selectedItem)
+                }
                 valueChanged?.invoke(adapter.selectedItem)
                 dismiss()
             }

--- a/app/src/main/java/com/dcrandroid/preference/PreferenceHelper.kt
+++ b/app/src/main/java/com/dcrandroid/preference/PreferenceHelper.kt
@@ -1,0 +1,29 @@
+package com.dcrandroid.preference
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+
+
+class PreferenceHelper {
+    private var mSharedPreferences: SharedPreferences? = null
+
+    fun PreferenceHelper(context: Context?) {
+        mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+    }
+
+    fun putInt(key: String?, value: Int) {
+        mSharedPreferences!!.edit().putInt(key, value).apply()
+    }
+
+    fun getInt(key: String?, defaultValue: Int): Int {
+        return mSharedPreferences!!.getInt(key, defaultValue)
+    }
+
+    fun clear() {
+        val editor = mSharedPreferences!!.edit()
+        editor.clear()
+        editor.apply()
+    }
+
+}

--- a/app/src/main/res/layout/crash_dialog.xml
+++ b/app/src/main/res/layout/crash_dialog.xml
@@ -10,7 +10,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="280dp"
     android:layout_height="wrap_content"
-    android:background="@color/white"
+    android:background="@color/surface"
     android:orientation="vertical">
 
     <LinearLayout

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -33,7 +33,7 @@
     <color name="turquoise">#2ED6A1</color>
     <color name="darkGreen">#3CC39A</color>
     <color name="colorError">#ed6d47</color>
-    <color name="colorDisabled">#c4cbd2</color>
+    <color name="colorDisabled">#999B9C</color>
     <color name="orangeTextColor">#ED6D47</color>
     <color name="pinview_active_color">#2DD8A3</color>
 </resources>


### PR DESCRIPTION
Resolves #602, Resolves #590, Resolves #578

This PR;
- fixes the issue where dark mode option was ignored for launch screen
- fixes the issue where disabled texts wasn't easily distinguishable from enabled texts
- fixes the issue where the crash dialog text wasn't visible