### PR TITLE
privacy: Skip "Setup needed accounts" page if the wallet has just one account

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/privacy/SetupMixerAccounts.kt
+++ b/app/src/main/java/com/dcrandroid/activities/privacy/SetupMixerAccounts.kt
@@ -53,12 +53,9 @@ class SetupMixerAccounts : BaseActivity() {
         }
 
         go_back.setOnClickListener { finish() }
-
-
     }
 
     private fun checkAccountNameConflict() {
-
         if (wallet.hasAccount(Constants.MIXED) || wallet.hasAccount(Constants.UNMIXED)) {
             InfoDialog(this)
                 .setDialogTitle(R.string.account_name_taken)

--- a/app/src/main/java/com/dcrandroid/activities/privacy/SetupPrivacy.kt
+++ b/app/src/main/java/com/dcrandroid/activities/privacy/SetupPrivacy.kt
@@ -9,19 +9,26 @@ package com.dcrandroid.activities.privacy
 import android.content.Intent
 import android.os.Bundle
 import android.text.Html
-import android.util.Log
-import android.widget.Toast
 import com.dcrandroid.R
 import com.dcrandroid.activities.BaseActivity
 import com.dcrandroid.data.Constants
 import com.dcrandroid.dialog.InfoDialog
+import com.dcrandroid.util.PassPromptTitle
+import com.dcrandroid.util.PassPromptUtil
+import com.dcrandroid.util.SnackBar
 import dcrlibwallet.Wallet
 import kotlinx.android.synthetic.main.account_row.*
+import kotlinx.android.synthetic.main.activity_setup_mixer_accounts.*
 import kotlinx.android.synthetic.main.activity_setup_privacy.*
+import kotlinx.android.synthetic.main.activity_setup_privacy.go_back
+import kotlinx.android.synthetic.main.activity_setup_privacy.wallet_name
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 class SetupPrivacy : BaseActivity() {
 
-    private lateinit var wallet: Wallet
+    private lateinit var wallet : Wallet
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_setup_privacy)
@@ -30,23 +37,83 @@ class SetupPrivacy : BaseActivity() {
         wallet_name.text = wallet.name
 
         btn_setup_mixer.setOnClickListener {
-            if (wallet.accountsRaw.count > 1) {
-                val intent = Intent(this, SetupMixerAccounts::class.java)
-                intent.putExtra(Constants.WALLET_ID, wallet.id)
-                finish()
-                startActivity(intent)
-            }
-            else {
-                InfoDialog(this)
-                    .setDialogTitle(getString(R.string.mixer_setup_error_title))
-                    .setMessage(getString(R.string.mixer_setup_error_desc))
-                    .setNegativeButton(getString(R.string.ok))
-                    .show()
+            // Check for account name "imported" and subtract 1 from total account count
+            if (wallet.accounts.toString().contains("imported", ignoreCase = true)) {
+                val walletCount = wallet.accountsRaw.count - 1
+                if (walletCount > 2) {
+                    val intent = Intent(this, SetupMixerAccounts::class.java)
+                    intent.putExtra(Constants.WALLET_ID, wallet.id)
+                    finish()
+                    startActivity(intent)
+                } else {
+                    InfoDialog(this)
+                        .setDialogTitle(getString(R.string.privacy_intro_dialog_title))
+                        .setMessage(Html.fromHtml(getString(R.string.privacy_intro_dialog_desc)))
+                        .setNegativeButton(getString(R.string.cancel))
+                        .setPositiveButton(
+                            getString(R.string.begin_setup)
+                        ) { _, _ ->
+                            checkAccountNameConflict()
+                        }
+                        .show()
+                }
+                go_back.setOnClickListener { finish() }
+
+                multiWallet!!.setBoolConfigValueForKey(Constants.CHECKED_PRIVACY_PAGE, true)
             }
         }
-
-        go_back.setOnClickListener { finish() }
-
-        multiWallet!!.setBoolConfigValueForKey(Constants.CHECKED_PRIVACY_PAGE, true)
     }
+
+    private fun checkAccountNameConflict() {
+        if (wallet.hasAccount(Constants.MIXED) || wallet.hasAccount(Constants.UNMIXED)) {
+            InfoDialog(this)
+                .setDialogTitle(R.string.account_name_taken)
+                .setMessage(R.string.account_name_conflict_dialog_desc)
+                .setIcon(R.drawable.ic_alert2, R.drawable.grey_dialog_bg)
+                .cancelable(false)
+                .setPositiveButton(
+                    R.string.go_back_rename
+                ) { dialog, _ ->
+                    dialog.dismiss()
+                    finish()
+                }
+                .show()
+            return
+        }
+
+        beginAutoSetup()
+    }
+
+    private fun beginAutoSetup() {
+        val title = PassPromptTitle(
+            R.string.confirm_create_needed_accounts,
+            R.string.confirm_create_needed_accounts,
+            R.string.confirm_create_needed_accounts
+        )
+        PassPromptUtil(this, wallet.id, title, allowFingerprint = true) { dialog, passphrase ->
+
+            if (passphrase == null) {
+                return@PassPromptUtil true
+            }
+
+            GlobalScope.launch(Dispatchers.Default) {
+                try {
+                    wallet.createMixerAccounts(Constants.MIXED, Constants.UNMIXED, passphrase)
+                    multiWallet!!.setBoolConfigValueForKey(Constants.HAS_SETUP_PRIVACY, true)
+                    val intent = Intent(this@SetupPrivacy, AccountMixerActivity::class.java)
+                    intent.putExtra(Constants.WALLET_ID, wallet.id)
+                    dialog?.dismissAllowingStateLoss()
+                    startActivity(intent)
+                    finish()
+                    SnackBar.showText(this@SetupPrivacy, R.string.mixer_setup_completed)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+
+                    PassPromptUtil.handleError(this@SetupPrivacy, e, dialog!!)
+                }
+            }
+            false
+        }.show()
+    }
+
 }

--- a/app/src/main/java/com/dcrandroid/activities/privacy/SetupPrivacy.kt
+++ b/app/src/main/java/com/dcrandroid/activities/privacy/SetupPrivacy.kt
@@ -8,10 +8,15 @@ package com.dcrandroid.activities.privacy
 
 import android.content.Intent
 import android.os.Bundle
+import android.text.Html
+import android.util.Log
+import android.widget.Toast
 import com.dcrandroid.R
 import com.dcrandroid.activities.BaseActivity
 import com.dcrandroid.data.Constants
+import com.dcrandroid.dialog.InfoDialog
 import dcrlibwallet.Wallet
+import kotlinx.android.synthetic.main.account_row.*
 import kotlinx.android.synthetic.main.activity_setup_privacy.*
 
 class SetupPrivacy : BaseActivity() {
@@ -25,10 +30,19 @@ class SetupPrivacy : BaseActivity() {
         wallet_name.text = wallet.name
 
         btn_setup_mixer.setOnClickListener {
-            val intent = Intent(this, SetupMixerAccounts::class.java)
-            intent.putExtra(Constants.WALLET_ID, wallet.id)
-            finish()
-            startActivity(intent)
+            if (wallet.accountsRaw.count > 1) {
+                val intent = Intent(this, SetupMixerAccounts::class.java)
+                intent.putExtra(Constants.WALLET_ID, wallet.id)
+                finish()
+                startActivity(intent)
+            }
+            else {
+                InfoDialog(this)
+                    .setDialogTitle(getString(R.string.mixer_setup_error_title))
+                    .setMessage(getString(R.string.mixer_setup_error_desc))
+                    .setNegativeButton(getString(R.string.ok))
+                    .show()
+            }
         }
 
         go_back.setOnClickListener { finish() }

--- a/app/src/main/java/com/dcrandroid/util/Utils.kt
+++ b/app/src/main/java/com/dcrandroid/util/Utils.kt
@@ -437,4 +437,5 @@ object Utils {
         val blockSize = statFs.blockSizeLong
         return blocks * blockSize / 1048576L // convert to megabytes
     }
+
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -603,6 +603,8 @@
     <string name="setup_mixer_btn_title">Set up mixer for this wallet</string>
     <string name="privacy_intro_dialog_title">Set up mixer by creating two needed accounts</string>
     <string name="privacy_intro_dialog_desc"><![CDATA[Two dedicated accounts (“mixed” & “unmixed”) will be created in order to use the mixer.<br/><br/><b><font color="#091440">This action cannot be undone.</font></b>]]></string>
+    <string name="mixer_setup_error_title">Cannot setup mixer for this wallet</string>
+    <string name="mixer_setup_error_desc">Please add another account to this wallet.</string>
     <string name="begin_setup">Begin setup</string>
     <string name="mixer_setup_completed">Mixer setup completed</string>
     <string name="ready_to_mix">Ready to mix</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -603,8 +603,6 @@
     <string name="setup_mixer_btn_title">Set up mixer for this wallet</string>
     <string name="privacy_intro_dialog_title">Set up mixer by creating two needed accounts</string>
     <string name="privacy_intro_dialog_desc"><![CDATA[Two dedicated accounts (“mixed” & “unmixed”) will be created in order to use the mixer.<br/><br/><b><font color="#091440">This action cannot be undone.</font></b>]]></string>
-    <string name="mixer_setup_error_title">Cannot setup mixer for this wallet</string>
-    <string name="mixer_setup_error_desc">Please add another account to this wallet.</string>
     <string name="begin_setup">Begin setup</string>
     <string name="mixer_setup_completed">Mixer setup completed</string>
     <string name="ready_to_mix">Ready to mix</string>


### PR DESCRIPTION
Resolves https://github.com/planetdecred/dcrandroid/issues/622.

While trying to setup mixer for a wallet, if the wallet has just one account, the "set up needed accounts" page is skipped, and the user is redirected to auto setup.
This is because the "set up needed accounts" page provides the user with the option to use manual mixer, which isn't possible which just one account in a wallet.

**Screenshot**

<img width="300" alt="Screenshot 2022-04-09 at 02 02 22" src="https://user-images.githubusercontent.com/53499828/162550407-d9b99736-7ea5-499e-8bff-39c87328fccd.png">


