### PR TITLE
Prevent import of same wallet multiple times.

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/RestoreWalletActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/RestoreWalletActivity.kt
@@ -116,7 +116,11 @@ class RestoreWalletActivity : BaseActivity() {
             }
 
             // Compare seed with existing wallets seed.
-            val walletID = multiWallet!!.walletWithSeed(enteredSeeds)
+            try {
+                val walletID = multiWallet!!.walletWithSeed(enteredSeeds)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
             if (walletID != -1L) {
                 SnackBar.showError(this, R.string.wallet_with_seed_exist)
                 return@setOnClickListener

--- a/app/src/main/java/com/dcrandroid/activities/RestoreWalletActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/RestoreWalletActivity.kt
@@ -116,8 +116,9 @@ class RestoreWalletActivity : BaseActivity() {
             }
 
             // Compare seed with existing wallets seed.
+            var walletID = 1L
             try {
-                val walletID = multiWallet!!.walletWithSeed(enteredSeeds)
+                walletID = multiWallet!!.walletWithSeed(enteredSeeds)
             } catch (e: Exception) {
                 e.printStackTrace()
             }

--- a/app/src/main/java/com/dcrandroid/activities/RestoreWalletActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/RestoreWalletActivity.kt
@@ -115,6 +115,13 @@ class RestoreWalletActivity : BaseActivity() {
                 return@setOnClickListener
             }
 
+            // Compare seed with existing wallets seed.
+            val walletID = multiWallet!!.walletWithSeed(enteredSeeds)
+            if (walletID != -1L) {
+                SnackBar.showError(this, R.string.wallet_with_seed_exist)
+                return@setOnClickListener
+            }
+
             if (multiWallet!!.loadedWalletsCount() == 0) {
                 requestWalletSpendingPass(getString(R.string.mywallet))
             } else {

--- a/app/src/main/java/com/dcrandroid/activities/RestoreWalletActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/RestoreWalletActivity.kt
@@ -121,7 +121,12 @@ class RestoreWalletActivity : BaseActivity() {
                 walletID = multiWallet!!.walletWithSeed(enteredSeeds)
             } catch (e: Exception) {
                 e.printStackTrace()
+                val op =
+                    this@RestoreWalletActivity.javaClass.name + ": restoreWalletActivity"
+                Dcrlibwallet.logT(op, e.message)
+                Utils.showErrorDialog(this@RestoreWalletActivity, op + ": " + e.message)
             }
+
             if (walletID != -1L) {
                 SnackBar.showError(this, R.string.wallet_with_seed_exist)
                 return@setOnClickListener

--- a/app/src/main/java/com/dcrandroid/dialog/CreateWatchOnlyWallet.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/CreateWatchOnlyWallet.kt
@@ -15,6 +15,7 @@ import androidx.core.text.HtmlCompat
 import com.dcrandroid.R
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
+import com.dcrandroid.util.SnackBar
 import com.dcrandroid.util.Utils
 import com.dcrandroid.view.util.InputHelper
 import dcrlibwallet.Dcrlibwallet
@@ -115,6 +116,15 @@ class CreateWatchOnlyWallet(val walletCreated: (wallet: Wallet) -> Unit) :
             val walletName = getWalletName()
             val extendedPublicKey = extendedPublicKeyInput?.validatedInput!!
 
+            if (isXPubUsed(extendedPublicKey)) {
+                SnackBar.showError(
+                    this@CreateWatchOnlyWallet.requireContext(),
+                    R.string.wallet_with_xpub_exist
+                )
+                toggleUI(true)
+                return@setOnClickListener
+            }
+
             GlobalScope.launch(Dispatchers.IO) {
                 try {
                     val wallet = multiWallet.createWatchOnlyWallet(walletName, extendedPublicKey)
@@ -158,6 +168,17 @@ class CreateWatchOnlyWallet(val walletCreated: (wallet: Wallet) -> Unit) :
         }
 
         return walletNameInput?.validatedInput!!
+    }
+
+    private fun isXPubUsed(xPub: String): Boolean {
+        var walletID = 1L
+        try {
+            walletID = multiWallet!!.walletWithXPub(xPub)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        if (walletID != -1L) return true
+        return false
     }
 
     private fun toggleUI(enable: Boolean) = GlobalScope.launch(Dispatchers.Main) {

--- a/app/src/main/java/com/dcrandroid/dialog/CreateWatchOnlyWallet.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/CreateWatchOnlyWallet.kt
@@ -176,6 +176,13 @@ class CreateWatchOnlyWallet(val walletCreated: (wallet: Wallet) -> Unit) :
             walletID = multiWallet!!.walletWithXPub(xPub)
         } catch (e: Exception) {
             e.printStackTrace()
+            val op =
+                this@CreateWatchOnlyWallet.javaClass.name + ": createWatchOnlyWallet"
+            Dcrlibwallet.logT(op, e.message)
+            Utils.showErrorDialog(
+                this@CreateWatchOnlyWallet.requireContext(),
+                op + ": " + e.message
+            )
         }
         if (walletID != -1L) return true
         return false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,7 +141,7 @@
     <string name="invalid_password">Password entered was not valid.</string>
     <string name="failed_to_open_wallet">Failed to open wallet</string>
     <string name="wallet_with_seed_exist">A wallet with an identical seed already exists.</string>
-    <string name="wallet_with_xpub_exist">A wallet with an identical extended public key already exists..</string>
+    <string name="wallet_with_xpub_exist">A wallet with an identical extended public key already exists.</string>
     <!--/Wallet-->
 
     <!--Transaction-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,6 +141,7 @@
     <string name="invalid_password">Password entered was not valid.</string>
     <string name="failed_to_open_wallet">Failed to open wallet</string>
     <string name="wallet_with_seed_exist">A wallet with an identical seed already exists.</string>
+    <string name="wallet_with_xpub_exist">A wallet with an identical extended public key already exists..</string>
     <!--/Wallet-->
 
     <!--Transaction-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,7 @@
     <string name="invalid_pin">PIN entered was not valid.</string>
     <string name="invalid_password">Password entered was not valid.</string>
     <string name="failed_to_open_wallet">Failed to open wallet</string>
+    <string name="wallet_with_seed_exist">A wallet with an identical seed already exists.</string>
     <!--/Wallet-->
 
     <!--Transaction-->


### PR DESCRIPTION
This PR closes #627. 

It prevents users from using same seed to restore the same 
wallet multiple times. Also stops users from using same xpub to import watch-only wallet multiple 

**Screenshots**
<img src="https://user-images.githubusercontent.com/4796738/165381616-f9acc459-5e92-4a23-ab75-aa3a93fa29dd.jpeg" width="300">
<img src="https://user-images.githubusercontent.com/4796738/165381638-9d6d8bc2-f776-4473-8a39-102a65f85195.jpeg" width="300">
